### PR TITLE
feat(app): Task 5 — Feature Flag branching + server-side job polling for playlist actions

### DIFF
--- a/apps/www/src/features/localization/resources/en/common.json
+++ b/apps/www/src/features/localization/resources/en/common.json
@@ -190,7 +190,9 @@
       "pending": "Pending",
       "processing": "Processing",
       "completed": "Completed",
-      "error": "Error"
+      "error": "Error",
+      "cancelled": "Cancelled",
+      "cancel": "Cancel"
     },
     "copying-playlist": "Copying {{title}} ...",
     "created-playlist": "Created {{title}} !",

--- a/apps/www/src/features/localization/resources/ja/common.json
+++ b/apps/www/src/features/localization/resources/ja/common.json
@@ -190,7 +190,9 @@
       "pending": "保留中",
       "processing": "処理中",
       "completed": "完了",
-      "error": "エラー"
+      "error": "エラー",
+      "cancelled": "キャンセル済み",
+      "cancel": "キャンセル"
     },
     "copying-playlist": "{{title}} をコピーしています...",
     "created-playlist": "{{title}} を作成しました！",

--- a/apps/www/src/features/playlist/components/actions/copy-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/copy-action.tsx
@@ -11,12 +11,17 @@ import type { PlaylistId } from "@/entities/ids";
 import { Provider } from "@/entities/provider";
 import { useFocusedAccount } from "@/features/accounts";
 import { useSession } from "@/lib/auth-client";
+import { FeatureFlagName } from "@/lib/feature-flags";
+import type { EnqueueJobRequest } from "@/lib/schemas/jobs";
+import { OperationType } from "@/lib/schemas/jobs";
+import { useFeatureFlag } from "@/presentation/hooks/useFeatureFlag";
 import { JobsBuilder } from "@/usecase/command/jobs";
 import { AddPlaylistItemJob } from "@/usecase/command/jobs/add-playlist-item";
 import { CreatePlaylistJob } from "@/usecase/command/jobs/create-playlist";
 import { CopyPlaylistUsecase } from "@/usecase/copy-playlist";
 import { useHistory } from "../../contexts/history";
 import { useSelectedPlaylists } from "../../contexts/selected-playlists";
+import { useServerJobs } from "../../contexts/server-jobs";
 import { useTask } from "../../contexts/tasks";
 import { PlaylistPrivacy } from "../../entities";
 import {
@@ -48,12 +53,47 @@ function useCopyAction(t: TFunction) {
       removeTask,
     },
   } = useTask();
+  const isServerSide = useFeatureFlag(
+    FeatureFlagName.serverSidePlaylistActions,
+  );
+  const { addJob } = useServerJobs();
 
   const handleCopy = async () => {
     if (!session || !focusedAccount) return;
     setIsOpen(false);
 
     emitGa4Event(ga4Events.copyPlaylist);
+
+    if (isServerSide) {
+      const copyTasks = selectedPlaylists.map(async (playlist) => {
+        const request: EnqueueJobRequest = {
+          type: "copy",
+          accId: focusedAccount.id,
+          sourcePlaylistId: playlist.id,
+          sourceAccId:
+            playlist.accountId !== focusedAccount.id
+              ? playlist.accountId
+              : undefined,
+          targetPlaylistId: targetId ?? undefined,
+          allowDuplicate: allowDuplicates,
+          privacy: "unlisted",
+        };
+        const res = await fetch("/api/v1/jobs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(request),
+        });
+        if (!res.ok) return;
+        const { jobId } = (await res.json()) as { jobId: string };
+        addJob({
+          jobId,
+          type: OperationType.Copy,
+          label: t("task-progress.copying-playlist", { title: playlist.title }),
+        });
+      });
+      await Promise.all(copyTasks);
+      return;
+    }
 
     const copyTasks = selectedPlaylists.map(async (playlist) => {
       const jobs = new JobsBuilder();

--- a/apps/www/src/features/playlist/components/actions/copy-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/copy-action.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { TFunction } from "i18next";
+import { enqueueSnackbar } from "notistack";
 import { useState } from "react";
 import { emitGa4Event } from "@/common/emit-ga4-event";
 import { sleep } from "@/common/sleep";
@@ -83,7 +84,16 @@ function useCopyAction(t: TFunction) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(request),
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          enqueueSnackbar(
+            t("task-progress.failed-to-copy-playlist", {
+              title: playlist.title,
+              code: res.status,
+            }),
+            { variant: "error" },
+          );
+          return;
+        }
         const { jobId } = (await res.json()) as { jobId: string };
         addJob({
           jobId,

--- a/apps/www/src/features/playlist/components/actions/deduplicate-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/deduplicate-action.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { TFunction } from "i18next";
+import { enqueueSnackbar } from "notistack";
 import { emitGa4Event } from "@/common/emit-ga4-event";
 import { sleep } from "@/common/sleep";
 import { ga4Events } from "@/constants";
@@ -55,7 +56,16 @@ function useDeduplicateAction(t: TFunction) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(request),
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          enqueueSnackbar(
+            t("task-progress.deduplicate.failed", {
+              title: playlist.title,
+              code: res.status,
+            }),
+            { variant: "error" },
+          );
+          return;
+        }
         const { jobId } = (await res.json()) as { jobId: string };
         addJob({
           jobId,

--- a/apps/www/src/features/playlist/components/actions/deduplicate-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/deduplicate-action.tsx
@@ -5,11 +5,16 @@ import { sleep } from "@/common/sleep";
 import { ga4Events } from "@/constants";
 import { Provider } from "@/entities/provider";
 import { useSession } from "@/lib/auth-client";
+import { FeatureFlagName } from "@/lib/feature-flags";
+import type { EnqueueJobRequest } from "@/lib/schemas/jobs";
+import { OperationType } from "@/lib/schemas/jobs";
+import { useFeatureFlag } from "@/presentation/hooks/useFeatureFlag";
 import { JobsBuilder } from "@/usecase/command/jobs";
 import { RemovePlaylistItemJob } from "@/usecase/command/jobs/remove-playlist-item";
 import { DeduplicatePlaylistUsecase } from "@/usecase/deduplicate-playlist";
 import { useHistory } from "../../contexts/history";
 import { useSelectedPlaylists } from "../../contexts/selected-playlists";
+import { useServerJobs } from "../../contexts/server-jobs";
 import { useTask } from "../../contexts/tasks";
 import { useInvalidatePlaylistsQuery } from "../../queries/use-playlists";
 import { PlaylistActionButton } from "../playlist-action-button";
@@ -30,9 +35,40 @@ function useDeduplicateAction(t: TFunction) {
   } = useTask();
   const invalidatePlaylistsQuery = useInvalidatePlaylistsQuery();
   const { selectedPlaylists } = useSelectedPlaylists();
+  const isServerSide = useFeatureFlag(
+    FeatureFlagName.serverSidePlaylistActions,
+  );
+  const { addJob } = useServerJobs();
 
   return async () => {
     if (!session) return;
+
+    if (isServerSide) {
+      const deduplicateTasks = selectedPlaylists.map(async (playlist) => {
+        const request: EnqueueJobRequest = {
+          type: "deduplicate",
+          accId: playlist.accountId,
+          targetPlaylistId: playlist.id,
+        };
+        const res = await fetch("/api/v1/jobs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(request),
+        });
+        if (!res.ok) return;
+        const { jobId } = (await res.json()) as { jobId: string };
+        addJob({
+          jobId,
+          type: OperationType.Deduplicate,
+          label: t("task-progress.deduplicate.processing", {
+            title: playlist.title,
+          }),
+        });
+      });
+      await Promise.all(deduplicateTasks);
+      return;
+    }
+
     const deduplicateTasks = selectedPlaylists.map(async (playlist) => {
       const taskId = await createTask(
         TaskType.Deduplicate,

--- a/apps/www/src/features/playlist/components/actions/extract-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/extract-action.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { TFunction } from "i18next";
+import { enqueueSnackbar } from "notistack";
 import { useCallback, useState } from "react";
 import { emitGa4Event } from "@/common/emit-ga4-event";
 import { sleep } from "@/common/sleep";
@@ -128,14 +129,23 @@ function useExtractAction(t: TFunction) {
         allowDuplicate: allowDuplicates,
         privacy: "unlisted",
       };
+      const joinedTitles = selectedPlaylists.map((p) => p.title).join(", ");
       const res = await fetch("/api/v1/jobs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(request),
       });
-      if (!res.ok) return;
+      if (!res.ok) {
+        enqueueSnackbar(
+          t("task-progress.extract.failed", {
+            title: joinedTitles,
+            code: res.status,
+          }),
+          { variant: "error" },
+        );
+        return;
+      }
       const { jobId } = (await res.json()) as { jobId: string };
-      const joinedTitles = selectedPlaylists.map((p) => p.title).join(", ");
       addJob({
         jobId,
         type: OperationType.Extract,

--- a/apps/www/src/features/playlist/components/actions/extract-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/extract-action.tsx
@@ -13,6 +13,10 @@ import { Provider } from "@/entities/provider";
 import { useFocusedAccount } from "@/features/accounts";
 import type { Playlist } from "@/features/playlist/entities";
 import { useSession } from "@/lib/auth-client";
+import { FeatureFlagName } from "@/lib/feature-flags";
+import type { EnqueueJobRequest } from "@/lib/schemas/jobs";
+import { OperationType } from "@/lib/schemas/jobs";
+import { useFeatureFlag } from "@/presentation/hooks/useFeatureFlag";
 import { JobsBuilder } from "@/usecase/command/jobs";
 import { AddPlaylistItemJob } from "@/usecase/command/jobs/add-playlist-item";
 import { CreatePlaylistJob } from "@/usecase/command/jobs/create-playlist";
@@ -20,6 +24,7 @@ import { ExtractPlaylistItemUsecase } from "@/usecase/extract-playlist-item";
 import { FetchFullPlaylistUsecase } from "@/usecase/fetch-full-playlist";
 import { useHistory } from "../../contexts/history";
 import { useSelectedPlaylists } from "../../contexts/selected-playlists";
+import { useServerJobs } from "../../contexts/server-jobs";
 import { useTask } from "../../contexts/tasks";
 import { type FullPlaylist, PlaylistPrivacy } from "../../entities";
 import {
@@ -39,6 +44,10 @@ function useExtractAction(t: TFunction) {
   const [isOpen, setIsOpen] = useState(false);
   const [targetId, setTargetId] = useState<PlaylistId | null>(null);
   const [allowDuplicates, setAllowDuplicates] = useState(false);
+  const isServerSide = useFeatureFlag(
+    FeatureFlagName.serverSidePlaylistActions,
+  );
+  const { addJob } = useServerJobs();
 
   const [_artists, setArtists] = useState<string[]>([]);
   const [artistMultiOptions, setArtistMultiOptions] = useState<Option[]>([]);
@@ -103,12 +112,42 @@ function useExtractAction(t: TFunction) {
     setIsOpen(false);
     setSelectedArtists([]);
     if (!session || !focusedAccount) return;
+
+    emitGa4Event(ga4Events.extractPlaylist);
+
+    if (isServerSide) {
+      const request: EnqueueJobRequest = {
+        type: "extract",
+        accId: focusedAccount.id,
+        sourcePlaylists: selectedPlaylists.map((p) => ({
+          id: p.id,
+          accId: p.accountId,
+        })),
+        targetPlaylistId: targetId ?? undefined,
+        artistNames: selectedArtists.map((o) => o.value),
+        allowDuplicate: allowDuplicates,
+        privacy: "unlisted",
+      };
+      const res = await fetch("/api/v1/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      });
+      if (!res.ok) return;
+      const { jobId } = (await res.json()) as { jobId: string };
+      const joinedTitles = selectedPlaylists.map((p) => p.title).join(", ");
+      addJob({
+        jobId,
+        type: OperationType.Extract,
+        label: `${t("task-progress.creating-new-playlist")} (${joinedTitles})`,
+      });
+      return;
+    }
+
     const taskId = await createTask(
       TaskType.Extract,
       t("task-progress.creating-new-playlist"),
     );
-
-    emitGa4Event(ga4Events.extractPlaylist);
 
     const jobs = new JobsBuilder();
 

--- a/apps/www/src/features/playlist/components/actions/merge-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/merge-action.tsx
@@ -11,12 +11,17 @@ import type { PlaylistId } from "@/entities/ids";
 import { Provider } from "@/entities/provider";
 import { useFocusedAccount } from "@/features/accounts";
 import { useSession } from "@/lib/auth-client";
+import { FeatureFlagName } from "@/lib/feature-flags";
+import type { EnqueueJobRequest } from "@/lib/schemas/jobs";
+import { OperationType } from "@/lib/schemas/jobs";
+import { useFeatureFlag } from "@/presentation/hooks/useFeatureFlag";
 import { JobsBuilder } from "@/usecase/command/jobs";
 import { AddPlaylistItemJob } from "@/usecase/command/jobs/add-playlist-item";
 import { CreatePlaylistJob } from "@/usecase/command/jobs/create-playlist";
 import { MergePlaylistUsecase } from "@/usecase/merge-playlist";
 import { useHistory } from "../../contexts/history";
 import { useSelectedPlaylists } from "../../contexts/selected-playlists";
+import { useServerJobs } from "../../contexts/server-jobs";
 import { useTask } from "../../contexts/tasks";
 import { PlaylistPrivacy } from "../../entities";
 import {
@@ -49,12 +54,44 @@ function useMergeAction(t: TFunction) {
       removeTask,
     },
   } = useTask();
+  const isServerSide = useFeatureFlag(
+    FeatureFlagName.serverSidePlaylistActions,
+  );
+  const { addJob } = useServerJobs();
 
   const handleMerge = async () => {
     if (!session || !focusedAccount) return;
     setIsOpen(false);
 
     emitGa4Event(ga4Events.mergePlaylists);
+
+    if (isServerSide) {
+      const request: EnqueueJobRequest = {
+        type: "merge",
+        accId: focusedAccount.id,
+        sourcePlaylists: selectedPlaylists.map((p) => ({
+          id: p.id,
+          accId: p.accountId,
+        })),
+        targetPlaylistId: targetId ?? undefined,
+        allowDuplicate: allowDuplicates,
+        privacy: "unlisted",
+      };
+      const res = await fetch("/api/v1/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      });
+      if (!res.ok) return;
+      const { jobId } = (await res.json()) as { jobId: string };
+      const joinedTitles = selectedPlaylists.map((p) => p.title).join(", ");
+      addJob({
+        jobId,
+        type: OperationType.Merge,
+        label: `${t("task-progress.creating-new-playlist")} (${joinedTitles})`,
+      });
+      return;
+    }
 
     const jobs = new JobsBuilder();
 

--- a/apps/www/src/features/playlist/components/actions/merge-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/merge-action.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { TFunction } from "i18next";
+import { enqueueSnackbar } from "notistack";
 import { useState } from "react";
 import { emitGa4Event } from "@/common/emit-ga4-event";
 import { sleep } from "@/common/sleep";
@@ -77,14 +78,23 @@ function useMergeAction(t: TFunction) {
         allowDuplicate: allowDuplicates,
         privacy: "unlisted",
       };
+      const joinedTitles = selectedPlaylists.map((p) => p.title).join(", ");
       const res = await fetch("/api/v1/jobs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(request),
       });
-      if (!res.ok) return;
+      if (!res.ok) {
+        enqueueSnackbar(
+          t("task-progress.failed-to-merge-playlist", {
+            title: joinedTitles,
+            code: res.status,
+          }),
+          { variant: "error" },
+        );
+        return;
+      }
       const { jobId } = (await res.json()) as { jobId: string };
-      const joinedTitles = selectedPlaylists.map((p) => p.title).join(", ");
       addJob({
         jobId,
         type: OperationType.Merge,

--- a/apps/www/src/features/playlist/components/actions/shuffle-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/shuffle-action.tsx
@@ -5,11 +5,16 @@ import { sleep } from "@/common/sleep";
 import { ga4Events } from "@/constants";
 import { Provider } from "@/entities/provider";
 import { useSession } from "@/lib/auth-client";
+import { FeatureFlagName } from "@/lib/feature-flags";
+import type { EnqueueJobRequest } from "@/lib/schemas/jobs";
+import { OperationType } from "@/lib/schemas/jobs";
+import { useFeatureFlag } from "@/presentation/hooks/useFeatureFlag";
 import { JobsBuilder } from "@/usecase/command/jobs";
 import { UpdatePlaylistItemPositionJob } from "@/usecase/command/jobs/update-playlist-item-position";
 import { ShufflePlaylistUsecase } from "@/usecase/shuffle-playlist";
 import { useHistory } from "../../contexts/history";
 import { useSelectedPlaylists } from "../../contexts/selected-playlists";
+import { useServerJobs } from "../../contexts/server-jobs";
 import { useTask } from "../../contexts/tasks";
 import { useInvalidatePlaylistsQuery } from "../../queries/use-playlists";
 import { PlaylistActionButton } from "../playlist-action-button";
@@ -30,9 +35,41 @@ function useShuffleAction(t: TFunction) {
   } = useTask();
   const invalidatePlaylistsQuery = useInvalidatePlaylistsQuery();
   const { selectedPlaylists } = useSelectedPlaylists();
+  const isServerSide = useFeatureFlag(
+    FeatureFlagName.serverSidePlaylistActions,
+  );
+  const { addJob } = useServerJobs();
 
   return async () => {
     if (!session) return;
+
+    if (isServerSide) {
+      const shuffleTasks = selectedPlaylists.map(async (playlist) => {
+        const request: EnqueueJobRequest = {
+          type: "shuffle",
+          accId: playlist.accountId,
+          targetPlaylistId: playlist.id,
+          ratio: 0.4,
+        };
+        const res = await fetch("/api/v1/jobs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(request),
+        });
+        if (!res.ok) return;
+        const { jobId } = (await res.json()) as { jobId: string };
+        addJob({
+          jobId,
+          type: OperationType.Shuffle,
+          label: t("task-progress.shuffle.processing", {
+            title: playlist.title,
+          }),
+        });
+      });
+      await Promise.all(shuffleTasks);
+      return;
+    }
+
     const shuffleTasks = selectedPlaylists.map(async (playlist) => {
       const taskId = await createTask(
         TaskType.Shuffle,

--- a/apps/www/src/features/playlist/components/actions/shuffle-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/shuffle-action.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { TFunction } from "i18next";
+import { enqueueSnackbar } from "notistack";
 import { emitGa4Event } from "@/common/emit-ga4-event";
 import { sleep } from "@/common/sleep";
 import { ga4Events } from "@/constants";
@@ -56,7 +57,16 @@ function useShuffleAction(t: TFunction) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(request),
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          enqueueSnackbar(
+            t("task-progress.shuffle.failed", {
+              title: playlist.title,
+              code: res.status,
+            }),
+            { variant: "error" },
+          );
+          return;
+        }
         const { jobId } = (await res.json()) as { jobId: string };
         addJob({
           jobId,

--- a/apps/www/src/features/playlist/components/server-jobs-monitor.tsx
+++ b/apps/www/src/features/playlist/components/server-jobs-monitor.tsx
@@ -1,0 +1,164 @@
+"use client";
+import {
+  AlertCircle,
+  CheckCircle,
+  Copy,
+  Filter,
+  GitMerge,
+  ListX,
+  Shuffle,
+  X,
+} from "lucide-react";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { JobStatus, OperationType } from "@/lib/schemas/jobs";
+import { useT } from "@/presentation/hooks/t/client";
+import { type ServerJob, useServerJobs } from "../contexts/server-jobs";
+import { useJobPoller } from "../hooks/use-job-poller";
+import { useInvalidatePlaylistsQuery } from "../queries/use-playlists";
+
+function getJobIcon(type: ServerJob["type"]) {
+  switch (type) {
+    case OperationType.Copy:
+      return <Copy className="h-4 w-4" />;
+    case OperationType.Merge:
+      return <GitMerge className="h-4 w-4" />;
+    case OperationType.Extract:
+      return <Filter className="h-4 w-4" />;
+    case OperationType.Deduplicate:
+      return <ListX className="h-4 w-4" />;
+    case OperationType.Shuffle:
+      return <Shuffle className="h-4 w-4" />;
+  }
+}
+
+interface ServerJobItemProps {
+  job: ServerJob;
+  onRemove: (jobId: string) => void;
+  lang: string;
+}
+
+function ServerJobItem({ job, onRemove, lang }: ServerJobItemProps) {
+  const { t } = useT(lang);
+  const { data } = useJobPoller(job.jobId);
+  const invalidatePlaylistsQuery = useInvalidatePlaylistsQuery();
+
+  const status = data?.status ?? JobStatus.Pending;
+  const progress = data?.progress ?? 0;
+  const isTerminal =
+    status === JobStatus.Completed ||
+    status === JobStatus.Failed ||
+    status === JobStatus.Cancelled;
+  const jobId = job.jobId;
+
+  useEffect(() => {
+    if (data?.status === JobStatus.Completed) {
+      invalidatePlaylistsQuery();
+      const timer = setTimeout(() => onRemove(jobId), 2000);
+      return () => clearTimeout(timer);
+    }
+    if (
+      data?.status === JobStatus.Failed ||
+      data?.status === JobStatus.Cancelled
+    ) {
+      const timer = setTimeout(() => onRemove(jobId), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [data, invalidatePlaylistsQuery, onRemove, jobId]);
+
+  async function handleCancel() {
+    await fetch(`/api/v1/jobs/${job.jobId}/cancel`, { method: "PATCH" });
+  }
+
+  function getStatusIcon() {
+    if (status === JobStatus.Completed)
+      return <CheckCircle className="h-4 w-4 text-green-500" />;
+    if (status === JobStatus.Failed)
+      return <AlertCircle className="h-4 w-4 text-red-500" />;
+    return null;
+  }
+
+  const dotColor =
+    status === JobStatus.Processing || status === JobStatus.Pending
+      ? "bg-blue-500"
+      : status === JobStatus.Completed
+        ? "bg-green-500"
+        : status === JobStatus.Failed
+          ? "bg-red-500"
+          : "bg-gray-500";
+
+  const statusLabel =
+    status === JobStatus.Processing || status === JobStatus.Pending
+      ? t("task-progress.common.processing")
+      : status === JobStatus.Completed
+        ? t("task-progress.common.completed")
+        : status === JobStatus.Failed
+          ? t("task-progress.common.error")
+          : t("task-progress.common.cancelled");
+
+  return (
+    <div className="rounded-md bg-gray-900 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <div className={`rounded-full p-1.5 ${dotColor}`}>
+            {getJobIcon(job.type)}
+          </div>
+          <span className="text-sm text-white">{job.label}</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          {getStatusIcon()}
+          {!isTerminal && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 p-0 text-gray-400 hover:text-white"
+              onClick={handleCancel}
+            >
+              <X className="h-3 w-3" />
+              <span className="sr-only">
+                {t("task-progress.common.cancel")}
+              </span>
+            </Button>
+          )}
+        </div>
+      </div>
+      <Progress
+        value={progress}
+        className="h-2"
+        indicatorClassName={dotColor}
+      />
+      <div className="mt-1 flex justify-between">
+        <span className="text-gray-400 text-xs">{statusLabel}</span>
+        <span className="text-gray-400 text-xs">{Math.round(progress)}%</span>
+      </div>
+    </div>
+  );
+}
+
+export function ServerJobsMonitor({ lang }: { lang: string }) {
+  const { t } = useT(lang);
+  const { jobs, removeJob } = useServerJobs();
+
+  if (jobs.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-gray-700 bg-gray-800 p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="font-medium text-white">
+          {t("task-progress.common.title")}
+        </h3>
+      </div>
+      <div className="max-h-60 space-y-3 overflow-y-auto">
+        {jobs.map((job) => (
+          <ServerJobItem
+            key={job.jobId}
+            job={job}
+            onRemove={removeJob}
+            lang={lang}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/www/src/features/playlist/components/server-jobs-monitor.tsx
+++ b/apps/www/src/features/playlist/components/server-jobs-monitor.tsx
@@ -55,19 +55,18 @@ function ServerJobItem({ job, onRemove, lang }: ServerJobItemProps) {
   const jobId = job.jobId;
 
   useEffect(() => {
-    if (data?.status === JobStatus.Completed) {
+    if (status === JobStatus.Completed) {
       invalidatePlaylistsQuery();
-      const timer = setTimeout(() => onRemove(jobId), 2000);
-      return () => clearTimeout(timer);
     }
     if (
-      data?.status === JobStatus.Failed ||
-      data?.status === JobStatus.Cancelled
+      status === JobStatus.Completed ||
+      status === JobStatus.Failed ||
+      status === JobStatus.Cancelled
     ) {
       const timer = setTimeout(() => onRemove(jobId), 2000);
       return () => clearTimeout(timer);
     }
-  }, [data, invalidatePlaylistsQuery, onRemove, jobId]);
+  }, [status, invalidatePlaylistsQuery, onRemove, jobId]);
 
   async function handleCancel() {
     await fetch(`/api/v1/jobs/${job.jobId}/cancel`, { method: "PATCH" });

--- a/apps/www/src/features/playlist/components/server-jobs-monitor.tsx
+++ b/apps/www/src/features/playlist/components/server-jobs-monitor.tsx
@@ -41,10 +41,12 @@ interface ServerJobItemProps {
 
 function ServerJobItem({ job, onRemove, lang }: ServerJobItemProps) {
   const { t } = useT(lang);
-  const { data } = useJobPoller(job.jobId);
+  const { data, isError } = useJobPoller(job.jobId);
   const invalidatePlaylistsQuery = useInvalidatePlaylistsQuery();
 
-  const status = data?.status ?? JobStatus.Pending;
+  const status = isError
+    ? JobStatus.Failed
+    : (data?.status ?? JobStatus.Pending);
   const progress = data?.progress ?? 0;
   const isTerminal =
     status === JobStatus.Completed ||

--- a/apps/www/src/features/playlist/components/snackbar-provider.tsx
+++ b/apps/www/src/features/playlist/components/snackbar-provider.tsx
@@ -1,0 +1,7 @@
+"use client";
+import { SnackbarProvider } from "notistack";
+import type { PropsWithChildren } from "react";
+
+export function PlaylistSnackbarProvider({ children }: PropsWithChildren) {
+  return <SnackbarProvider>{children}</SnackbarProvider>;
+}

--- a/apps/www/src/features/playlist/contexts/server-jobs.tsx
+++ b/apps/www/src/features/playlist/contexts/server-jobs.tsx
@@ -1,0 +1,53 @@
+"use client";
+import {
+  createContext,
+  type PropsWithChildren,
+  use,
+  useCallback,
+  useState,
+} from "react";
+import type { JobType } from "@/lib/schemas/jobs";
+
+export type ServerJob = {
+  jobId: string;
+  type: JobType;
+  label: string;
+};
+
+interface ServerJobsContextValue {
+  jobs: ServerJob[];
+  addJob: (job: ServerJob) => void;
+  removeJob: (jobId: string) => void;
+}
+
+const ServerJobsContext = createContext<ServerJobsContextValue>({
+  jobs: [],
+  addJob: () => {
+    throw new Error("addJob called before ServerJobsProvider was mounted");
+  },
+  removeJob: () => {
+    throw new Error("removeJob called before ServerJobsProvider was mounted");
+  },
+});
+
+export function ServerJobsProvider({ children }: PropsWithChildren) {
+  const [jobs, setJobs] = useState<ServerJob[]>([]);
+
+  const addJob = useCallback((job: ServerJob) => {
+    setJobs((prev) => [...prev, job]);
+  }, []);
+
+  const removeJob = useCallback((jobId: string) => {
+    setJobs((prev) => prev.filter((j) => j.jobId !== jobId));
+  }, []);
+
+  return (
+    <ServerJobsContext.Provider value={{ jobs, addJob, removeJob }}>
+      {children}
+    </ServerJobsContext.Provider>
+  );
+}
+
+export function useServerJobs() {
+  return use(ServerJobsContext);
+}

--- a/apps/www/src/features/playlist/hooks/use-job-poller.ts
+++ b/apps/www/src/features/playlist/hooks/use-job-poller.ts
@@ -13,8 +13,8 @@ export function useJobPoller(jobId: string) {
   return useQuery({
     queryKey: ["job", jobId],
     queryFn: () => fetchJob(jobId),
+    retry: false,
     refetchInterval: (query) => {
-      if (query.state.status === "error") return false;
       const status = query.state.data?.status;
       if (
         status === JobStatus.Completed ||
@@ -22,6 +22,7 @@ export function useJobPoller(jobId: string) {
         status === JobStatus.Cancelled
       )
         return false;
+      if (query.state.status === "error") return 10000;
       return 2000;
     },
   });

--- a/apps/www/src/features/playlist/hooks/use-job-poller.ts
+++ b/apps/www/src/features/playlist/hooks/use-job-poller.ts
@@ -1,0 +1,27 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import type { JobResponse } from "@/lib/schemas/jobs";
+import { JobStatus } from "@/lib/schemas/jobs";
+
+async function fetchJob(jobId: string): Promise<JobResponse> {
+  const res = await fetch(`/api/v1/jobs/${jobId}`);
+  if (!res.ok) throw new Error(`Failed to fetch job: ${res.status}`);
+  return res.json() as Promise<JobResponse>;
+}
+
+export function useJobPoller(jobId: string) {
+  return useQuery({
+    queryKey: ["job", jobId],
+    queryFn: () => fetchJob(jobId),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (
+        status === JobStatus.Completed ||
+        status === JobStatus.Failed ||
+        status === JobStatus.Cancelled
+      )
+        return false;
+      return 2000;
+    },
+  });
+}

--- a/apps/www/src/features/playlist/hooks/use-job-poller.ts
+++ b/apps/www/src/features/playlist/hooks/use-job-poller.ts
@@ -14,6 +14,7 @@ export function useJobPoller(jobId: string) {
     queryKey: ["job", jobId],
     queryFn: () => fetchJob(jobId),
     refetchInterval: (query) => {
+      if (query.state.status === "error") return false;
       const status = query.state.data?.status;
       if (
         status === JobStatus.Completed ||

--- a/apps/www/src/features/playlist/view.tsx
+++ b/apps/www/src/features/playlist/view.tsx
@@ -5,10 +5,12 @@ import { PinnedPlaylistsProvider } from "@/features/pinned-playlists/provider";
 import { useServerT } from "@/presentation/hooks/t/server";
 import { PlaylistActions } from "./components/playlist-actions";
 import { Playlists } from "./components/playlists";
+import { ServerJobsMonitor } from "./components/server-jobs-monitor";
 import { TasksMonitor } from "./components/tasks-monitor";
 import { HistoryProvider } from "./contexts/history";
 import { SearchQueryContextProvider } from "./contexts/search";
 import { SelectedPlaylistsContextProvider } from "./contexts/selected-playlists";
+import { ServerJobsProvider } from "./contexts/server-jobs";
 import { TaskProvider } from "./contexts/tasks";
 
 interface PlaylistsViewProps {
@@ -22,14 +24,17 @@ export async function PlaylistsView({ lang }: PlaylistsViewProps) {
       <PinnedPlaylistsProvider initialIds={initialPinnedIds}>
         <SelectedPlaylistsContextProvider>
           <TaskProvider>
-            <HistoryProvider>
-              <SearchQueryContextProvider>
-                <AccountTabs />
-                <TasksMonitor lang={lang} />
-                <PlaylistActions lang={lang} />
-                <Playlists />
-              </SearchQueryContextProvider>
-            </HistoryProvider>
+            <ServerJobsProvider>
+              <HistoryProvider>
+                <SearchQueryContextProvider>
+                  <AccountTabs />
+                  <TasksMonitor lang={lang} />
+                  <ServerJobsMonitor lang={lang} />
+                  <PlaylistActions lang={lang} />
+                  <Playlists />
+                </SearchQueryContextProvider>
+              </HistoryProvider>
+            </ServerJobsProvider>
           </TaskProvider>
         </SelectedPlaylistsContextProvider>
       </PinnedPlaylistsProvider>

--- a/apps/www/src/features/playlist/view.tsx
+++ b/apps/www/src/features/playlist/view.tsx
@@ -1,3 +1,4 @@
+import { SnackbarProvider } from "notistack";
 import type { PropsWithChildren } from "react";
 import { AccountTabs } from "@/features/accounts";
 import { getPinnedPlaylistIds } from "@/features/pinned-playlists/actions";
@@ -25,15 +26,17 @@ export async function PlaylistsView({ lang }: PlaylistsViewProps) {
         <SelectedPlaylistsContextProvider>
           <TaskProvider>
             <ServerJobsProvider>
-              <HistoryProvider>
-                <SearchQueryContextProvider>
-                  <AccountTabs />
-                  <TasksMonitor lang={lang} />
-                  <ServerJobsMonitor lang={lang} />
-                  <PlaylistActions lang={lang} />
-                  <Playlists />
-                </SearchQueryContextProvider>
-              </HistoryProvider>
+              <SnackbarProvider>
+                <HistoryProvider>
+                  <SearchQueryContextProvider>
+                    <AccountTabs />
+                    <TasksMonitor lang={lang} />
+                    <ServerJobsMonitor lang={lang} />
+                    <PlaylistActions lang={lang} />
+                    <Playlists />
+                  </SearchQueryContextProvider>
+                </HistoryProvider>
+              </SnackbarProvider>
             </ServerJobsProvider>
           </TaskProvider>
         </SelectedPlaylistsContextProvider>

--- a/apps/www/src/features/playlist/view.tsx
+++ b/apps/www/src/features/playlist/view.tsx
@@ -1,4 +1,3 @@
-import { SnackbarProvider } from "notistack";
 import type { PropsWithChildren } from "react";
 import { AccountTabs } from "@/features/accounts";
 import { getPinnedPlaylistIds } from "@/features/pinned-playlists/actions";
@@ -7,6 +6,7 @@ import { useServerT } from "@/presentation/hooks/t/server";
 import { PlaylistActions } from "./components/playlist-actions";
 import { Playlists } from "./components/playlists";
 import { ServerJobsMonitor } from "./components/server-jobs-monitor";
+import { PlaylistSnackbarProvider } from "./components/snackbar-provider";
 import { TasksMonitor } from "./components/tasks-monitor";
 import { HistoryProvider } from "./contexts/history";
 import { SearchQueryContextProvider } from "./contexts/search";
@@ -26,7 +26,7 @@ export async function PlaylistsView({ lang }: PlaylistsViewProps) {
         <SelectedPlaylistsContextProvider>
           <TaskProvider>
             <ServerJobsProvider>
-              <SnackbarProvider>
+              <PlaylistSnackbarProvider>
                 <HistoryProvider>
                   <SearchQueryContextProvider>
                     <AccountTabs />
@@ -36,7 +36,7 @@ export async function PlaylistsView({ lang }: PlaylistsViewProps) {
                     <Playlists />
                   </SearchQueryContextProvider>
                 </HistoryProvider>
-              </SnackbarProvider>
+              </PlaylistSnackbarProvider>
             </ServerJobsProvider>
           </TaskProvider>
         </SelectedPlaylistsContextProvider>


### PR DESCRIPTION
## Summary

- Adds `serverSidePlaylistActions` feature flag branching to all 5 playlist action components (Copy, Merge, Extract, Deduplicate, Shuffle)
- When the flag is **ON**: actions POST to `/api/v1/jobs` and register the returned `jobId` into `ServerJobsContext` — no client-side execution
- When the flag is **OFF**: existing client-side logic is unchanged
- New `ServerJobsMonitor` component polls each job via `useJobPoller` (2-second interval) and displays progress with a cancel button
- `ServerJobsProvider` is always mounted alongside `TaskProvider`; the monitor is hidden when no server jobs are active (rollout: 0 → zero impact on existing users)

## Changes

### New files
- `features/playlist/hooks/use-job-poller.ts` — `useQuery`-based polling hook, stops at terminal states
- `features/playlist/contexts/server-jobs.tsx` — `ServerJobsContext` + `ServerJobsProvider` + `useServerJobs`
- `features/playlist/components/server-jobs-monitor.tsx` — job progress UI with cancel button per job

### Modified files
- `features/playlist/view.tsx` — mount `ServerJobsProvider` + `ServerJobsMonitor`
- `actions/copy|merge|extract|deduplicate|shuffle-action.tsx` — FF branching; use `JobStatus`/`OperationType` enums from `@playlistwizard/job-queue`
- `localization/resources/en|ja/common.json` — add `cancel` / `cancelled` i18n keys

## Test plan

- [ ] Flag OFF (default): all 5 actions work as before via `TasksMonitor`; `ServerJobsMonitor` is not visible
- [ ] Flag ON (`add-feature-flag-user.ts`): action → job card appears in `ServerJobsMonitor`, progress bar updates every 2s, card auto-removes 2s after completion, playlist list refreshes
- [ ] Cancel button calls `PATCH /api/v1/jobs/:id/cancel`; job transitions to `cancelled` and card is removed
- [ ] All tests pass: `pnpm test`
- [ ] Lint/format clean: `pnpm lint && pnpm format`