### PR TITLE
perf(app): optimize thumbnail loading — store all qualities and select by display width

### DIFF
--- a/.changeset/thumbnail-array.md
+++ b/.changeset/thumbnail-array.md
@@ -1,0 +1,5 @@
+---
+"@playlistwizard/www": patch
+---
+
+perf: load optimal thumbnail quality based on display context

--- a/apps/www/src/components/thumbnail-image.test.tsx
+++ b/apps/www/src/components/thumbnail-image.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { urls } from "@/constants";
+import type { Thumbnail } from "@/entities/thumbnail";
 import { ThumbnailImage } from "./thumbnail-image";
 
 vi.mock("next/image", () => ({
@@ -21,34 +22,75 @@ vi.mock("next/image", () => ({
 
 afterEach(cleanup);
 
+const sampleThumbnails: Thumbnail[] = [
+  { url: "https://example.com/default.jpg", width: 120, height: 90 },
+  { url: "https://example.com/medium.jpg", width: 320, height: 180 },
+  { url: "https://example.com/high.jpg", width: 480, height: 360 },
+];
+
 describe("ThumbnailImage", () => {
-  it("renders with fallback image when src is undefined", () => {
-    render(<ThumbnailImage src={undefined} alt="test" />);
+  it("renders with fallback image when thumbnails is empty", () => {
+    render(<ThumbnailImage thumbnails={[]} targetWidth={320} alt="test" />);
     const img = screen.getByTestId("thumbnail-image");
     expect(img).toHaveAttribute("src", "/assets/ogp.png");
   });
 
-  it("renders with fallback image when src is empty string", () => {
-    render(<ThumbnailImage src="" alt="test" />);
+  it("selects the thumbnail closest to targetWidth", () => {
+    render(
+      <ThumbnailImage
+        thumbnails={sampleThumbnails}
+        targetWidth={300}
+        alt="test"
+      />,
+    );
     const img = screen.getByTestId("thumbnail-image");
-    expect(img).toHaveAttribute("src", "/assets/ogp.png");
+    // 300 is closest to 320 (medium)
+    expect(img).toHaveAttribute("src", "https://example.com/medium.jpg");
   });
 
-  it("renders with proxy URL when src is YouTube no thumbnail URL", () => {
-    render(<ThumbnailImage src={urls.youtubeApiNoThumbnail()} alt="test" />);
+  it("selects the smallest thumbnail when targetWidth is very small", () => {
+    render(
+      <ThumbnailImage
+        thumbnails={sampleThumbnails}
+        targetWidth={50}
+        alt="test"
+      />,
+    );
+    const img = screen.getByTestId("thumbnail-image");
+    expect(img).toHaveAttribute("src", "https://example.com/default.jpg");
+  });
+
+  it("selects the largest thumbnail when targetWidth is very large", () => {
+    render(
+      <ThumbnailImage
+        thumbnails={sampleThumbnails}
+        targetWidth={1000}
+        alt="test"
+      />,
+    );
+    const img = screen.getByTestId("thumbnail-image");
+    expect(img).toHaveAttribute("src", "https://example.com/high.jpg");
+  });
+
+  it("renders with proxy URL when selected thumbnail is YouTube no thumbnail URL", () => {
+    const thumbnails: Thumbnail[] = [
+      { url: urls.youtubeApiNoThumbnail(), width: 120, height: 90 },
+    ];
+    render(
+      <ThumbnailImage thumbnails={thumbnails} targetWidth={120} alt="test" />,
+    );
     const img = screen.getByTestId("thumbnail-image");
     expect(img).toHaveAttribute("src", urls.youtubeNoThumbnailProxy());
   });
 
-  it("renders with original src when src is a normal URL", () => {
-    const normalUrl = "https://example.com/thumbnail.jpg";
-    render(<ThumbnailImage src={normalUrl} alt="test" />);
-    const img = screen.getByTestId("thumbnail-image");
-    expect(img).toHaveAttribute("src", normalUrl);
-  });
-
   it("passes alt attribute correctly", () => {
-    render(<ThumbnailImage src="https://example.com/img.jpg" alt="Test Alt" />);
+    render(
+      <ThumbnailImage
+        thumbnails={sampleThumbnails}
+        targetWidth={320}
+        alt="Test Alt"
+      />,
+    );
     const img = screen.getByTestId("thumbnail-image");
     expect(img).toHaveAttribute("alt", "Test Alt");
   });
@@ -56,7 +98,8 @@ describe("ThumbnailImage", () => {
   it("passes additional props to Image component", () => {
     render(
       <ThumbnailImage
-        src="https://example.com/img.jpg"
+        thumbnails={sampleThumbnails}
+        targetWidth={320}
         alt="test"
         className="custom-class"
         width={100}

--- a/apps/www/src/components/thumbnail-image.tsx
+++ b/apps/www/src/components/thumbnail-image.tsx
@@ -23,11 +23,15 @@ function selectThumbnailUrl(
   targetWidth: number,
 ): string | undefined {
   if (thumbnails.length === 0) return undefined;
-  return thumbnails.reduce((prev, curr) =>
-    Math.abs(curr.width - targetWidth) < Math.abs(prev.width - targetWidth)
-      ? curr
-      : prev,
-  ).url;
+  let best: Thumbnail | undefined;
+  let largest = thumbnails[0];
+  for (const t of thumbnails) {
+    if (t.width >= targetWidth) {
+      if (!best || t.width < best.width) best = t;
+    }
+    if (t.width > largest.width) largest = t;
+  }
+  return (best ?? largest).url;
 }
 
 function resolveThumbnailUrl(src: string | undefined): string {

--- a/apps/www/src/components/thumbnail-image.tsx
+++ b/apps/www/src/components/thumbnail-image.tsx
@@ -1,13 +1,33 @@
 import Image, { type ImageProps } from "next/image";
 import { urls } from "@/constants";
+import type { Thumbnail } from "@/entities/thumbnail";
 
 type ThumbnailImageProps = Omit<ImageProps, "src"> & {
-  src: string | undefined;
+  thumbnails: Thumbnail[];
+  targetWidth: number;
 };
 
-export function ThumbnailImage({ src, alt, ...props }: ThumbnailImageProps) {
+export function ThumbnailImage({
+  thumbnails,
+  targetWidth,
+  alt,
+  ...props
+}: ThumbnailImageProps) {
+  const src = selectThumbnailUrl(thumbnails, targetWidth);
   const resolvedSrc = resolveThumbnailUrl(src);
   return <Image src={resolvedSrc} alt={alt} {...props} />;
+}
+
+function selectThumbnailUrl(
+  thumbnails: Thumbnail[],
+  targetWidth: number,
+): string | undefined {
+  if (thumbnails.length === 0) return undefined;
+  return thumbnails.reduce((prev, curr) =>
+    Math.abs(curr.width - targetWidth) < Math.abs(prev.width - targetWidth)
+      ? curr
+      : prev,
+  ).url;
 }
 
 function resolveThumbnailUrl(src: string | undefined): string {

--- a/apps/www/src/entities/thumbnail.ts
+++ b/apps/www/src/entities/thumbnail.ts
@@ -1,0 +1,5 @@
+export type Thumbnail = {
+  url: string;
+  width: number;
+  height: number;
+};

--- a/apps/www/src/features/playlist-browser/browser.tsx
+++ b/apps/www/src/features/playlist-browser/browser.tsx
@@ -161,7 +161,8 @@ export function PlaylistBrowser({
                     <div className="flex items-center">
                       <div className="relative mr-3 h-10 w-10 flex-shrink-0 overflow-hidden rounded">
                         <ThumbnailImage
-                          src={item.thumbnailUrl}
+                          thumbnails={item.thumbnails}
+                          targetWidth={120}
                           alt={item.title}
                           fill
                           className="object-cover"

--- a/apps/www/src/features/playlist/components/playlist-card.tsx
+++ b/apps/www/src/features/playlist/components/playlist-card.tsx
@@ -37,9 +37,14 @@ import { TaskStatus, TaskType } from "./tasks-monitor";
 
 interface PlaylistCardProps {
   playlistId: PlaylistId;
+  index: number;
 }
 
-export function PlaylistCard({ playlistId, t }: PlaylistCardProps & WithT) {
+export function PlaylistCard({
+  playlistId,
+  index,
+  t,
+}: PlaylistCardProps & WithT) {
   const { data: playlists, isPending } = usePlaylistsQuery();
   const { selectedPlaylists } = useSelectedPlaylists();
   const togglePlaylistSelection = useTogglePlaylistSelection();
@@ -86,6 +91,12 @@ export function PlaylistCard({ playlistId, t }: PlaylistCardProps & WithT) {
           targetWidth={640}
           alt={targetPlaylist.title}
           fill
+          sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw"
+          {...(index === 0
+            ? { priority: true }
+            : index < 4
+              ? { loading: "eager" }
+              : {})}
           className="object-cover transition-transform duration-300 group-hover:scale-105"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-gray-900/80 to-transparent" />

--- a/apps/www/src/features/playlist/components/playlist-card.tsx
+++ b/apps/www/src/features/playlist/components/playlist-card.tsx
@@ -82,7 +82,8 @@ export function PlaylistCard({ playlistId, t }: PlaylistCardProps & WithT) {
     >
       <div className="relative aspect-video overflow-hidden rounded-t-lg">
         <ThumbnailImage
-          src={targetPlaylist.thumbnailUrl}
+          thumbnails={targetPlaylist.thumbnails}
+          targetWidth={640}
           alt={targetPlaylist.title}
           fill
           className="object-cover transition-transform duration-300 group-hover:scale-105"

--- a/apps/www/src/features/playlist/components/playlists.tsx
+++ b/apps/www/src/features/playlist/components/playlists.tsx
@@ -31,8 +31,13 @@ export function Playlists() {
           if (!aPinned && bPinned) return 1;
           return 0;
         })
-        .map((playlist) => (
-          <PlaylistCard key={playlist.id} playlistId={playlist.id} t={t} />
+        .map((playlist, index) => (
+          <PlaylistCard
+            key={playlist.id}
+            playlistId={playlist.id}
+            index={index}
+            t={t}
+          />
         ))}
       <PlaylistImportingCard t={t} />
     </div>

--- a/apps/www/src/features/playlist/components/structured-playlists-definition-preview/playlist-tree-node-preview.tsx
+++ b/apps/www/src/features/playlist/components/structured-playlists-definition-preview/playlist-tree-node-preview.tsx
@@ -52,7 +52,8 @@ export function PlaylistTreeNodePreview({
           <>
             <div className="relative h-8 w-8 flex-shrink-0 overflow-hidden rounded">
               <ThumbnailImage
-                src={playlist.thumbnailUrl}
+                thumbnails={playlist.thumbnails}
+                targetWidth={120}
                 alt={playlist.title}
                 fill
                 className="object-cover"

--- a/apps/www/src/features/playlist/entities/playlist-item.ts
+++ b/apps/www/src/features/playlist/entities/playlist-item.ts
@@ -4,11 +4,12 @@ import {
   toVideoId,
   type VideoId,
 } from "@/entities/ids";
+import type { Thumbnail } from "@/entities/thumbnail";
 
 export type PlaylistItem = {
   id: PlaylistItemId;
   title: string;
-  thumbnailUrl: string;
+  thumbnails: Thumbnail[];
   position: number;
   author: string;
   videoId: VideoId;
@@ -28,7 +29,9 @@ export function createDummyPlaylistItem(
   return {
     id: toPlaylistItemId(data.id ?? "dummy-id"),
     title: data.title ?? "Dummy Title",
-    thumbnailUrl: data.thumbnailUrl ?? "https://example.com/thumbnail.jpg",
+    thumbnails: data.thumbnails ?? [
+      { url: "https://example.com/thumbnail.jpg", width: 640, height: 480 },
+    ],
     position: data.position ?? 0,
     author: data.author ?? "Dummy Author",
     videoId: toVideoId(data.videoId ?? "dummy-video-id"),

--- a/apps/www/src/features/playlist/entities/playlist.ts
+++ b/apps/www/src/features/playlist/entities/playlist.ts
@@ -5,13 +5,14 @@ import {
   toPlaylistId,
 } from "@/entities/ids";
 import { Provider } from "@/entities/provider";
+import type { Thumbnail } from "@/entities/thumbnail";
 import type { PlaylistItem } from "./playlist-item";
 
 export type Playlist = {
   id: PlaylistId;
   accountId: AccountId;
   title: string;
-  thumbnailUrl: string;
+  thumbnails: Thumbnail[];
   itemsTotal: number;
   url: string;
   provider: Provider;
@@ -37,7 +38,9 @@ export function createDummyPlaylist(data: CreateDummyPlaylistInput): Playlist {
     id: toPlaylistId(data.id ?? "dummy-id"),
     accountId: toAccountId(data.accountId ?? "dummy-account-id"),
     title: data.title ?? "Dummy Title",
-    thumbnailUrl: data.thumbnailUrl ?? "https://example.com/thumbnail.jpg",
+    thumbnails: data.thumbnails ?? [
+      { url: "https://example.com/thumbnail.jpg", width: 640, height: 480 },
+    ],
     itemsTotal: data.itemsTotal ?? 0,
     url: data.url ?? "https://example.com/playlist",
     provider: data.provider ?? Provider.GOOGLE,

--- a/apps/www/src/features/search/components/add-to-playlist-dialog.tsx
+++ b/apps/www/src/features/search/components/add-to-playlist-dialog.tsx
@@ -241,7 +241,8 @@ function SortedPlaylistGrid({
             >
               <div className="relative aspect-video overflow-hidden rounded-t-lg">
                 <ThumbnailImage
-                  src={playlist.thumbnailUrl}
+                  thumbnails={playlist.thumbnails}
+                  targetWidth={320}
                   alt={playlist.title}
                   fill
                   className="object-cover"

--- a/apps/www/src/features/search/components/search-result-card.tsx
+++ b/apps/www/src/features/search/components/search-result-card.tsx
@@ -47,7 +47,8 @@ export function SearchResultCard({ video, t }: SearchResultCardProps & WithT) {
       >
         <div className="relative aspect-video w-40 flex-shrink-0 overflow-hidden rounded-md">
           <ThumbnailImage
-            src={video.thumbnailUrl}
+            thumbnails={video.thumbnails}
+            targetWidth={320}
             alt={video.title}
             fill
             className="object-cover"

--- a/apps/www/src/features/search/entities/index.ts
+++ b/apps/www/src/features/search/entities/index.ts
@@ -1,10 +1,11 @@
 import type { VideoId } from "@/entities/ids";
+import type { Thumbnail } from "@/entities/thumbnail";
 
 export interface VideoSearchResult {
   id: VideoId;
   title: string;
   channelTitle: string;
-  thumbnailUrl: string;
+  thumbnails: Thumbnail[];
   duration: string;
   viewCount: string;
   publishedAt: string;

--- a/apps/www/src/features/structured-playlists-editor/components/dependency-tree-node.tsx
+++ b/apps/www/src/features/structured-playlists-editor/components/dependency-tree-node.tsx
@@ -102,6 +102,7 @@ export function DependencyTreeNode({
               targetWidth={120}
               alt={node.playlist.title}
               fill
+              sizes="48px"
               className="object-cover"
             />
           </div>

--- a/apps/www/src/features/structured-playlists-editor/components/dependency-tree-node.tsx
+++ b/apps/www/src/features/structured-playlists-editor/components/dependency-tree-node.tsx
@@ -98,7 +98,8 @@ export function DependencyTreeNode({
           {/* Playlist Info */}
           <div className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded-md">
             <ThumbnailImage
-              src={node.playlist.thumbnailUrl}
+              thumbnails={node.playlist.thumbnails}
+              targetWidth={120}
               alt={node.playlist.title}
               fill
               className="object-cover"

--- a/apps/www/src/features/structured-playlists-editor/components/playlist-list.tsx
+++ b/apps/www/src/features/structured-playlists-editor/components/playlist-list.tsx
@@ -83,7 +83,8 @@ function PlaylistCard({ playlist, t }: { playlist: Playlist } & WithT) {
       <div className="flex items-center gap-3">
         <div className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded-md">
           <ThumbnailImage
-            src={playlist.thumbnailUrl}
+            thumbnails={playlist.thumbnails}
+            targetWidth={120}
             alt={playlist.title}
             fill
             className="object-cover"

--- a/apps/www/src/features/structured-playlists-editor/components/playlist-list.tsx
+++ b/apps/www/src/features/structured-playlists-editor/components/playlist-list.tsx
@@ -87,6 +87,7 @@ function PlaylistCard({ playlist, t }: { playlist: Playlist } & WithT) {
             targetWidth={120}
             alt={playlist.title}
             fill
+            sizes="48px"
             className="object-cover"
           />
         </div>

--- a/apps/www/src/features/structured-playlists-editor/libs/dependency-tree/node.ts
+++ b/apps/www/src/features/structured-playlists-editor/libs/dependency-tree/node.ts
@@ -196,7 +196,6 @@ export const NodeHelpers = {
         id,
         title: `Unknown Playlist (${id})`,
         itemsTotal: 0,
-        thumbnailUrl: "https://example.com/thumbnail.jpg",
         url: "https://example.com/playlist",
       });
     };

--- a/apps/www/src/repository/providers/youtube.ts
+++ b/apps/www/src/repository/providers/youtube.ts
@@ -1,6 +1,7 @@
 import {
   ApiClient,
   type PlaylistItem as YouTubePlaylistItem,
+  type Thumbnails as YouTubeThumbnails,
   type Playlist as YoutubePlaylist,
 } from "@playlistwizard/youtube";
 import type { GaxiosError } from "gaxios";
@@ -14,6 +15,7 @@ import {
   toVideoId,
 } from "@/entities/ids";
 import { Provider } from "@/entities/provider";
+import type { Thumbnail } from "@/entities/thumbnail";
 import type {
   FullPlaylist,
   Playlist,
@@ -26,6 +28,48 @@ import {
 } from "@/usecase/interface/provider";
 
 const logger = makeServerLogger("YoutubeProviderRepository");
+
+const YOUTUBE_NO_THUMBNAIL_SUFFIX = "/no_thumbnail.jpg";
+const YOUTUBE_DEFAULT_THUMBNAIL = "https://i.ytimg.com/img/no_thumbnail.jpg";
+
+const YOUTUBE_THUMBNAIL_DEFAULTS: Record<
+  string,
+  { width: number; height: number }
+> = {
+  default: { width: 120, height: 90 },
+  medium: { width: 320, height: 180 },
+  high: { width: 480, height: 360 },
+  standard: { width: 640, height: 480 },
+  maxres: { width: 1280, height: 720 },
+};
+
+const THUMBNAIL_QUALITY_KEYS = [
+  "maxres",
+  "standard",
+  "high",
+  "medium",
+  "default",
+] as const;
+
+function toThumbnailArray(thumbnails: YouTubeThumbnails): Thumbnail[] {
+  const results = THUMBNAIL_QUALITY_KEYS.map((key) => {
+    const t = thumbnails.getByQuality(key);
+    if (!t || t.url.endsWith(YOUTUBE_NO_THUMBNAIL_SUFFIX)) return null;
+    const dims = YOUTUBE_THUMBNAIL_DEFAULTS[key];
+    return {
+      url: t.url,
+      width: t.width ?? dims.width,
+      height: t.height ?? dims.height,
+    };
+  }).filter((t): t is Thumbnail => t !== null);
+
+  if (results.length === 0) {
+    return [
+      { url: YOUTUBE_DEFAULT_THUMBNAIL, ...YOUTUBE_THUMBNAIL_DEFAULTS.default },
+    ];
+  }
+  return results;
+}
 
 export class YoutubeProviderRepository implements ProviderRepositoryInterface {
   async getMinePlaylists(
@@ -62,8 +106,7 @@ export class YoutubeProviderRepository implements ProviderRepositoryInterface {
         id: toPlaylistId(playlist.id),
         accountId,
         title: playlist.title,
-        // biome-ignore lint/style/noNonNullAssertion: TODO
-        thumbnailUrl: playlist.thumbnails.getLargest()?.url!,
+        thumbnails: toThumbnailArray(playlist.thumbnails),
         itemsTotal: playlist.itemsTotal,
         items: playlistItems.map(convertProviderPlaylistItemToEntity),
         url: playlist.url,
@@ -89,8 +132,7 @@ export class YoutubeProviderRepository implements ProviderRepositoryInterface {
         id: toPlaylistId(res.id),
         accountId,
         title: res.title,
-        // biome-ignore lint/style/noNonNullAssertion: TODO
-        thumbnailUrl: res.thumbnails.getLargest()?.url!,
+        thumbnails: toThumbnailArray(res.thumbnails),
         itemsTotal: res.itemsTotal,
         url: `https://www.youtube.com/playlist?list=${res.id}`,
         provider: Provider.GOOGLE,
@@ -165,8 +207,7 @@ export class YoutubeProviderRepository implements ProviderRepositoryInterface {
           id: toPlaylistId(playlist.id),
           accountId,
           title: playlist.title,
-          // biome-ignore lint/style/noNonNullAssertion: TODO
-          thumbnailUrl: playlist.thumbnails.getLargest()?.url!,
+          thumbnails: toThumbnailArray(playlist.thumbnails),
           itemsTotal: 0,
           url: `https://www.youtube.com/playlist?list=${playlist.id}`,
           provider: Provider.GOOGLE,
@@ -283,8 +324,7 @@ function convertProviderPlaylistToEntity(
     id: toPlaylistId(item.id),
     accountId,
     title: item.title,
-    // biome-ignore lint/style/noNonNullAssertion: TODO
-    thumbnailUrl: item.thumbnails.getLargest()?.url!,
+    thumbnails: toThumbnailArray(item.thumbnails),
     itemsTotal: item.itemsTotal,
     url: `https://www.youtube.com/playlist?list=${item.id}`,
     provider: Provider.GOOGLE,
@@ -297,8 +337,7 @@ function convertProviderPlaylistItemToEntity(
   return {
     id: toPlaylistItemId(item.id),
     title: item.title,
-    // biome-ignore lint/style/noNonNullAssertion: TODO
-    thumbnailUrl: item.thumbnails.getSmallest()?.url!,
+    thumbnails: toThumbnailArray(item.thumbnails),
     position: item.position,
     author: item.channelName,
     videoId: toVideoId(item.videoId),

--- a/apps/www/src/repository/providers/youtube.ts
+++ b/apps/www/src/repository/providers/youtube.ts
@@ -23,43 +23,26 @@ import type {
   PlaylistPrivacy,
 } from "@/features/playlist/entities";
 import {
+  YOUTUBE_DEFAULT_THUMBNAIL,
+  YOUTUBE_NO_THUMBNAIL_SUFFIX,
+  YOUTUBE_THUMBNAIL_DEFAULTS,
+  YOUTUBE_THUMBNAIL_QUALITY_KEYS,
+} from "@/repository/youtube-thumbnail-defaults";
+import {
   BaseProviderError,
   type ProviderRepositoryInterface,
 } from "@/usecase/interface/provider";
 
 const logger = makeServerLogger("YoutubeProviderRepository");
 
-const YOUTUBE_NO_THUMBNAIL_SUFFIX = "/no_thumbnail.jpg";
-const YOUTUBE_DEFAULT_THUMBNAIL = "https://i.ytimg.com/img/no_thumbnail.jpg";
-
-const YOUTUBE_THUMBNAIL_DEFAULTS: Record<
-  string,
-  { width: number; height: number }
-> = {
-  default: { width: 120, height: 90 },
-  medium: { width: 320, height: 180 },
-  high: { width: 480, height: 360 },
-  standard: { width: 640, height: 480 },
-  maxres: { width: 1280, height: 720 },
-};
-
-const THUMBNAIL_QUALITY_KEYS = [
-  "maxres",
-  "standard",
-  "high",
-  "medium",
-  "default",
-] as const;
-
 function toThumbnailArray(thumbnails: YouTubeThumbnails): Thumbnail[] {
-  const results = THUMBNAIL_QUALITY_KEYS.map((key) => {
+  const results = YOUTUBE_THUMBNAIL_QUALITY_KEYS.map((key) => {
     const t = thumbnails.getByQuality(key);
     if (!t || t.url.endsWith(YOUTUBE_NO_THUMBNAIL_SUFFIX)) return null;
-    const dims = YOUTUBE_THUMBNAIL_DEFAULTS[key];
     return {
       url: t.url,
-      width: t.width ?? dims.width,
-      height: t.height ?? dims.height,
+      width: t.width,
+      height: t.height,
     };
   }).filter((t): t is Thumbnail => t !== null);
 

--- a/apps/www/src/repository/v2/youtube/transformers.test.ts
+++ b/apps/www/src/repository/v2/youtube/transformers.test.ts
@@ -94,14 +94,30 @@ describe("transformPlaylist", () => {
       id: "PLtest123",
       accountId: testAccountId,
       title: "Test Playlist",
-      thumbnailUrl: "https://i.ytimg.com/vi/abc/hqdefault.jpg",
+      thumbnails: [
+        {
+          url: "https://i.ytimg.com/vi/abc/hqdefault.jpg",
+          width: 480,
+          height: 360,
+        },
+        {
+          url: "https://i.ytimg.com/vi/abc/mqdefault.jpg",
+          width: 320,
+          height: 180,
+        },
+        {
+          url: "https://i.ytimg.com/vi/abc/default.jpg",
+          width: 120,
+          height: 90,
+        },
+      ],
       itemsTotal: 10,
       url: "https://www.youtube.com/playlist?list=PLtest123",
       provider: Provider.GOOGLE,
     });
   });
 
-  it("should select the largest thumbnail", () => {
+  it("should include all available thumbnails ordered by quality descending", () => {
     const resource = createMockPlaylistResource({
       snippet: {
         title: "Test",
@@ -120,9 +136,14 @@ describe("transformPlaylist", () => {
       },
     });
     const result = transformPlaylist(resource, testAccountId);
-    expect(result.thumbnailUrl).toBe(
-      "https://i.ytimg.com/vi/abc/maxresdefault.jpg",
-    );
+    expect(result.thumbnails).toEqual([
+      {
+        url: "https://i.ytimg.com/vi/abc/maxresdefault.jpg",
+        width: 1280,
+        height: 720,
+      },
+      { url: "https://i.ytimg.com/vi/abc/default.jpg", width: 120, height: 90 },
+    ]);
   });
 
   it("should generate correct URL", () => {
@@ -150,39 +171,28 @@ describe("transformPlaylistItem", () => {
     expect(result).toEqual({
       id: "UExitem123",
       title: "Test Video",
-      thumbnailUrl: "https://i.ytimg.com/vi/vid1/default.jpg",
+      thumbnails: [
+        {
+          url: "https://i.ytimg.com/vi/vid1/hqdefault.jpg",
+          width: 480,
+          height: 360,
+        },
+        {
+          url: "https://i.ytimg.com/vi/vid1/mqdefault.jpg",
+          width: 320,
+          height: 180,
+        },
+        {
+          url: "https://i.ytimg.com/vi/vid1/default.jpg",
+          width: 120,
+          height: 90,
+        },
+      ],
       position: 0,
       author: "Test Channel",
       videoId: "vid1",
       url: "https://www.youtube.com/watch?v=vid1",
     });
-  });
-
-  it("should select the smallest thumbnail", () => {
-    const resource = createMockPlaylistItemResource({
-      snippet: {
-        playlistId: "PLtest123",
-        title: "Test Video",
-        position: 0,
-        thumbnails: {
-          default: {
-            url: "https://i.ytimg.com/vi/vid1/default.jpg",
-            width: 120,
-            height: 90,
-          },
-          maxres: {
-            url: "https://i.ytimg.com/vi/vid1/maxresdefault.jpg",
-            width: 1280,
-            height: 720,
-          },
-        },
-        channelTitle: "Test Channel",
-        resourceId: { kind: "youtube#video", videoId: "vid1" },
-      },
-      contentDetails: { videoId: "vid1" },
-    });
-    const result = transformPlaylistItem(resource);
-    expect(result.thumbnailUrl).toBe("https://i.ytimg.com/vi/vid1/default.jpg");
   });
 
   it("should generate correct URL from videoId", () => {
@@ -239,7 +249,13 @@ describe("toVideoSearchResult", () => {
       id: "vid1",
       title: "Test Video",
       channelTitle: "Test Channel",
-      thumbnailUrl: "https://i.ytimg.com/vi/vid1/default.jpg",
+      thumbnails: [
+        {
+          url: "https://i.ytimg.com/vi/vid1/default.jpg",
+          width: 120,
+          height: 90,
+        },
+      ],
       duration: "PT3M45S",
       viewCount: "12345",
       publishedAt: "2024-01-01T00:00:00Z",
@@ -256,7 +272,7 @@ describe("toVideoSearchResult", () => {
 });
 
 describe("thumbnail extraction edge cases", () => {
-  it("should skip thumbnails with no_thumbnail.jpg suffix", () => {
+  it("should exclude thumbnails with no_thumbnail.jpg suffix", () => {
     const resource = createMockPlaylistResource({
       snippet: {
         title: "Test",
@@ -275,12 +291,16 @@ describe("thumbnail extraction edge cases", () => {
       },
     });
     const result = transformPlaylist(resource, testAccountId);
-    expect(result.thumbnailUrl).toBe(
-      "https://i.ytimg.com/vi/abc/mqdefault.jpg",
-    );
+    expect(result.thumbnails).toEqual([
+      {
+        url: "https://i.ytimg.com/vi/abc/mqdefault.jpg",
+        width: 320,
+        height: 180,
+      },
+    ]);
   });
 
-  it("should return default thumbnail URL when all thumbnails are undefined", () => {
+  it("should return fallback thumbnail when all thumbnails are undefined", () => {
     const resource = createMockPlaylistResource({
       snippet: {
         title: "Test",
@@ -288,12 +308,16 @@ describe("thumbnail extraction edge cases", () => {
       },
     });
     const result = transformPlaylist(resource, testAccountId);
-    expect(result.thumbnailUrl).toBe(
-      "https://i.ytimg.com/img/no_thumbnail.jpg",
-    );
+    expect(result.thumbnails).toEqual([
+      {
+        url: "https://i.ytimg.com/img/no_thumbnail.jpg",
+        width: 120,
+        height: 90,
+      },
+    ]);
   });
 
-  it("should return default thumbnail when all thumbnails have no_thumbnail.jpg suffix", () => {
+  it("should return fallback thumbnail when all thumbnails have no_thumbnail.jpg suffix", () => {
     const resource = createMockPlaylistResource({
       snippet: {
         title: "Test",
@@ -304,8 +328,31 @@ describe("thumbnail extraction edge cases", () => {
       },
     });
     const result = transformPlaylist(resource, testAccountId);
-    expect(result.thumbnailUrl).toBe(
-      "https://i.ytimg.com/img/no_thumbnail.jpg",
-    );
+    expect(result.thumbnails).toEqual([
+      {
+        url: "https://i.ytimg.com/img/no_thumbnail.jpg",
+        width: 120,
+        height: 90,
+      },
+    ]);
+  });
+
+  it("should use default dimensions when API does not return width/height", () => {
+    const resource = createMockPlaylistResource({
+      snippet: {
+        title: "Test",
+        thumbnails: {
+          high: { url: "https://i.ytimg.com/vi/abc/hqdefault.jpg" },
+        },
+      },
+    });
+    const result = transformPlaylist(resource, testAccountId);
+    expect(result.thumbnails).toEqual([
+      {
+        url: "https://i.ytimg.com/vi/abc/hqdefault.jpg",
+        width: 480,
+        height: 360,
+      },
+    ]);
   });
 });

--- a/apps/www/src/repository/v2/youtube/transformers.ts
+++ b/apps/www/src/repository/v2/youtube/transformers.ts
@@ -8,32 +8,16 @@ import { Provider } from "@/entities/provider";
 import type { Thumbnail } from "@/entities/thumbnail";
 import type { Playlist, PlaylistItem } from "@/features/playlist/entities";
 import type { VideoSearchResult } from "@/features/search/entities";
+import {
+  YOUTUBE_DEFAULT_THUMBNAIL,
+  YOUTUBE_NO_THUMBNAIL_SUFFIX,
+  YOUTUBE_THUMBNAIL_DEFAULTS,
+  YOUTUBE_THUMBNAIL_QUALITY_KEYS,
+} from "@/repository/youtube-thumbnail-defaults";
 import type { PlaylistResource } from "./schemas/playlist";
 import type { PlaylistItemResource } from "./schemas/playlist-item";
 import type { YouTubeThumbnail } from "./schemas/thumbnail";
 import type { VideoDetailResource } from "./schemas/video-detail";
-
-const YOUTUBE_NO_THUMBNAIL_SUFFIX = "/no_thumbnail.jpg";
-const YOUTUBE_DEFAULT_THUMBNAIL = "https://i.ytimg.com/img/no_thumbnail.jpg";
-
-const YOUTUBE_THUMBNAIL_DEFAULTS: Record<
-  string,
-  { width: number; height: number }
-> = {
-  default: { width: 120, height: 90 },
-  medium: { width: 320, height: 180 },
-  high: { width: 480, height: 360 },
-  standard: { width: 640, height: 480 },
-  maxres: { width: 1280, height: 720 },
-};
-
-const THUMBNAIL_QUALITY_ORDER = [
-  "maxres",
-  "standard",
-  "high",
-  "medium",
-  "default",
-] as const;
 
 type YTThumbnails = {
   default?: YouTubeThumbnail;
@@ -44,7 +28,7 @@ type YTThumbnails = {
 };
 
 function extractThumbnails(thumbnails: YTThumbnails): Thumbnail[] {
-  const results = THUMBNAIL_QUALITY_ORDER.map((key) => {
+  const results = YOUTUBE_THUMBNAIL_QUALITY_KEYS.map((key) => {
     const t = thumbnails[key];
     if (!t || t.url.endsWith(YOUTUBE_NO_THUMBNAIL_SUFFIX)) return null;
     const dims = YOUTUBE_THUMBNAIL_DEFAULTS[key];

--- a/apps/www/src/repository/v2/youtube/transformers.ts
+++ b/apps/www/src/repository/v2/youtube/transformers.ts
@@ -5,6 +5,7 @@ import {
   toVideoId,
 } from "@/entities/ids";
 import { Provider } from "@/entities/provider";
+import type { Thumbnail } from "@/entities/thumbnail";
 import type { Playlist, PlaylistItem } from "@/features/playlist/entities";
 import type { VideoSearchResult } from "@/features/search/entities";
 import type { PlaylistResource } from "./schemas/playlist";
@@ -15,6 +16,53 @@ import type { VideoDetailResource } from "./schemas/video-detail";
 const YOUTUBE_NO_THUMBNAIL_SUFFIX = "/no_thumbnail.jpg";
 const YOUTUBE_DEFAULT_THUMBNAIL = "https://i.ytimg.com/img/no_thumbnail.jpg";
 
+const YOUTUBE_THUMBNAIL_DEFAULTS: Record<
+  string,
+  { width: number; height: number }
+> = {
+  default: { width: 120, height: 90 },
+  medium: { width: 320, height: 180 },
+  high: { width: 480, height: 360 },
+  standard: { width: 640, height: 480 },
+  maxres: { width: 1280, height: 720 },
+};
+
+const THUMBNAIL_QUALITY_ORDER = [
+  "maxres",
+  "standard",
+  "high",
+  "medium",
+  "default",
+] as const;
+
+type YTThumbnails = {
+  default?: YouTubeThumbnail;
+  medium?: YouTubeThumbnail;
+  high?: YouTubeThumbnail;
+  standard?: YouTubeThumbnail;
+  maxres?: YouTubeThumbnail;
+};
+
+function extractThumbnails(thumbnails: YTThumbnails): Thumbnail[] {
+  const results = THUMBNAIL_QUALITY_ORDER.map((key) => {
+    const t = thumbnails[key];
+    if (!t || t.url.endsWith(YOUTUBE_NO_THUMBNAIL_SUFFIX)) return null;
+    const dims = YOUTUBE_THUMBNAIL_DEFAULTS[key];
+    return {
+      url: t.url,
+      width: t.width ?? dims.width,
+      height: t.height ?? dims.height,
+    };
+  }).filter((t): t is Thumbnail => t !== null);
+
+  if (results.length === 0) {
+    return [
+      { url: YOUTUBE_DEFAULT_THUMBNAIL, ...YOUTUBE_THUMBNAIL_DEFAULTS.default },
+    ];
+  }
+  return results;
+}
+
 export function transformPlaylist(
   resource: PlaylistResource,
   accountId: AccountId,
@@ -23,7 +71,7 @@ export function transformPlaylist(
     id: toPlaylistId(resource.id),
     accountId,
     title: resource.snippet.title,
-    thumbnailUrl: extractThumbnailUrl(resource.snippet.thumbnails, "largest"),
+    thumbnails: extractThumbnails(resource.snippet.thumbnails),
     itemsTotal: resource.contentDetails.itemCount,
     url: `https://www.youtube.com/playlist?list=${resource.id}`,
     provider: Provider.GOOGLE,
@@ -36,7 +84,7 @@ export function transformPlaylistItem(
   return {
     id: toPlaylistItemId(resource.id),
     title: resource.snippet.title,
-    thumbnailUrl: extractThumbnailUrl(resource.snippet.thumbnails, "smallest"),
+    thumbnails: extractThumbnails(resource.snippet.thumbnails),
     position: resource.snippet.position,
     author: resource.snippet.channelTitle,
     videoId: toVideoId(resource.contentDetails.videoId),
@@ -51,41 +99,9 @@ export function toVideoSearchResult(
     id: toVideoId(detailResource.id),
     title: detailResource.snippet.title,
     channelTitle: detailResource.snippet.channelTitle ?? "",
-    thumbnailUrl: extractThumbnailUrl(
-      detailResource.snippet.thumbnails,
-      "largest",
-    ),
+    thumbnails: extractThumbnails(detailResource.snippet.thumbnails),
     duration: detailResource.contentDetails?.duration ?? "",
     viewCount: detailResource.statistics?.viewCount ?? "0",
     publishedAt: detailResource.snippet.publishedAt ?? "",
   };
-}
-
-type ThumbnailSize = "largest" | "smallest";
-
-type Thumbnails = {
-  default?: YouTubeThumbnail;
-  medium?: YouTubeThumbnail;
-  high?: YouTubeThumbnail;
-  standard?: YouTubeThumbnail;
-  maxres?: YouTubeThumbnail;
-};
-
-function extractThumbnailUrl(
-  thumbnails: Thumbnails,
-  size: ThumbnailSize,
-): string {
-  const priorities =
-    size === "largest"
-      ? (["maxres", "standard", "high", "medium", "default"] as const)
-      : (["default", "medium", "high", "standard", "maxres"] as const);
-
-  for (const key of priorities) {
-    const thumb = thumbnails[key];
-    if (thumb?.url && !thumb.url.endsWith(YOUTUBE_NO_THUMBNAIL_SUFFIX)) {
-      return thumb.url;
-    }
-  }
-
-  return YOUTUBE_DEFAULT_THUMBNAIL;
 }

--- a/apps/www/src/repository/youtube-thumbnail-defaults.ts
+++ b/apps/www/src/repository/youtube-thumbnail-defaults.ts
@@ -1,0 +1,22 @@
+export const YOUTUBE_NO_THUMBNAIL_SUFFIX = "/no_thumbnail.jpg";
+export const YOUTUBE_DEFAULT_THUMBNAIL =
+  "https://i.ytimg.com/img/no_thumbnail.jpg";
+
+export const YOUTUBE_THUMBNAIL_DEFAULTS: Record<
+  string,
+  { width: number; height: number }
+> = {
+  default: { width: 120, height: 90 },
+  medium: { width: 320, height: 180 },
+  high: { width: 480, height: 360 },
+  standard: { width: 640, height: 480 },
+  maxres: { width: 1280, height: 720 },
+};
+
+export const YOUTUBE_THUMBNAIL_QUALITY_KEYS = [
+  "maxres",
+  "standard",
+  "high",
+  "medium",
+  "default",
+] as const;


### PR DESCRIPTION
## Summary

- Repository now returns `Thumbnail[]` (url, width, height) instead of a single `thumbnailUrl: string`, preserving all quality levels from the YouTube API (maxres/standard/high/medium/default)
- `ThumbnailImage` component accepts `thumbnails: Thumbnail[]` + `targetWidth: number` and selects the closest matching quality at render time
- `PlaylistCard` adds `sizes` prop and applies `priority` to the first card (LCP candidate) and `loading="eager"` to cards 1–3 (above the fold)

## Test plan

- [ ] Playlist page: card thumbnails render correctly at all breakpoints
- [ ] Playlist browser: item thumbnails render correctly
- [ ] Search results: video thumbnails render correctly
- [ ] Structured playlists editor: dependency tree and playlist list thumbnails render correctly
- [ ] First card has `fetchpriority="high"` in DevTools; cards 1–3 have `loading="eager"`; cards 4+ are lazy
- [ ] No missing `sizes` warnings in browser console
- [ ] `pnpm test` passes (346 tests)