### PR TITLE
feat(app): adjust playlist grid columns based on sidebar state

### DIFF
--- a/apps/www/src/features/playlist/components/playlists.tsx
+++ b/apps/www/src/features/playlist/components/playlists.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useSidebar } from "@/components/ui/sidebar";
 import { usePinnedPlaylists } from "@/features/pinned-playlists/provider";
+import { cn } from "@/lib/cn";
 import { useT } from "@/presentation/hooks/t/client";
 import { useSearchQuery } from "../contexts/search";
 import { usePlaylistsQuery } from "../queries/use-playlists";
@@ -15,11 +17,19 @@ export function Playlists() {
   const { searchQuery } = useSearchQuery();
   const { data: playlists, isPending } = usePlaylistsQuery();
   const { pinnedIds } = usePinnedPlaylists();
+  const { state } = useSidebar();
 
   if (isPending) return <PlaylistsSkeleton />;
   const pinnedSet = new Set(pinnedIds);
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+    <div
+      className={cn(
+        "grid grid-cols-1 gap-4",
+        state !== "expanded"
+          ? "sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4" // sidebar is expanded
+          : "md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4",
+      )}
+    >
       {playlists
         .filter((playlist) =>
           playlist.title.toLowerCase().includes(searchQuery.toLowerCase()),


### PR DESCRIPTION
## Summary
- サイドバーの開閉状態（`useSidebar` の `state`）に応じてプレイリストグリッドのブレークポイントを切り替えるように変更
- サイドバー折りたたみ時: `sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4`（従来通り）
- サイドバー展開時: `md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4`（より広い画面幅で段階的に増加）

## Test plan
- [ ] サイドバー展開時に `/playlists` でグリッドが適切なカラム数で表示されること
- [ ] サイドバー折りたたみ時に従来のブレークポイントで表示されること
- [ ] サイドバーの開閉切り替えでグリッドが動的に変化すること