### PR TITLE
perf(app): cache branded auth session

### DIFF
--- a/apps/www/src/features/feedback/actions.ts
+++ b/apps/www/src/features/feedback/actions.ts
@@ -1,8 +1,6 @@
 "use server";
 
-import { headers } from "next/headers";
-import { toUserId } from "@/entities/ids";
-import { auth } from "@/lib/auth";
+import { getSession } from "@/repository/auth/session";
 import { feedbackDbRepository } from "@/repository/db/feedback/repository";
 import { FEEDBACK_CATEGORY_CONFIG, type FeedbackCategory } from "./constants";
 
@@ -14,11 +12,11 @@ export async function submitFeedback(data: {
   browser?: string;
   pageUrl?: string;
 }): Promise<{ success: boolean; error?: string }> {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) return { success: false, error: "Unauthorized" };
 
   await feedbackDbRepository.insert({
-    userId: toUserId(session.user.id),
+    userId: session.user.id,
     category: data.category,
     title: data.title,
     message: data.message,

--- a/apps/www/src/features/pinned-playlists/actions.ts
+++ b/apps/www/src/features/pinned-playlists/actions.ts
@@ -1,15 +1,14 @@
 "use server";
-import { headers } from "next/headers";
-import { type AccountId, type PlaylistId, toUserId } from "@/entities/ids";
-import { auth } from "@/lib/auth";
+import type { AccountId, PlaylistId } from "@/entities/ids";
+import { getSession } from "@/repository/auth/session";
 import { pinnedPlaylistsDbRepository } from "@/repository/db/pinned-playlists/repository";
 
 export async function getPinnedPlaylistIds(): Promise<PlaylistId[]> {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) return [];
 
   const rows = await pinnedPlaylistsDbRepository.findManyByUserId(
-    toUserId(session.user.id),
+    session.user.id,
   );
 
   return rows.map((row) => row.playlistId);
@@ -20,11 +19,11 @@ export async function pinPlaylist(
   provider: string,
   accountId: AccountId,
 ): Promise<void> {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) return;
 
   await pinnedPlaylistsDbRepository.insert({
-    userId: toUserId(session.user.id),
+    userId: session.user.id,
     accountId,
     playlistId,
     provider,
@@ -36,11 +35,11 @@ export async function unpinPlaylist(
   _provider: string,
   accountId: AccountId,
 ): Promise<void> {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) return;
 
   await pinnedPlaylistsDbRepository.delete(
-    toUserId(session.user.id),
+    session.user.id,
     accountId,
     playlistId,
   );

--- a/apps/www/src/features/structured-playlists-definition/actions.ts
+++ b/apps/www/src/features/structured-playlists-definition/actions.ts
@@ -3,19 +3,18 @@ import {
   type StructuredPlaylistsDefinition,
   StructuredPlaylistsDefinitionSchema,
 } from "@playlistwizard/core/structured-playlists";
-import { headers } from "next/headers";
-import { type AccountId, toUserId } from "@/entities/ids";
-import { auth } from "@/lib/auth";
+import type { AccountId } from "@/entities/ids";
+import { getSession } from "@/repository/auth/session";
 import { structuredPlaylistsDefinitionDbRepository } from "@/repository/db/structured-playlists-definition/repository";
 
 export async function getAllStructuredPlaylistsDefinitions(): Promise<
   Record<string, StructuredPlaylistsDefinition>
 > {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) return {};
 
   const rows = await structuredPlaylistsDefinitionDbRepository.findManyByUserId(
-    toUserId(session.user.id),
+    session.user.id,
   );
 
   const result: Record<string, StructuredPlaylistsDefinition> = {};
@@ -34,10 +33,10 @@ export async function saveStructuredPlaylistsDefinition(
   accId: AccountId,
   data: StructuredPlaylistsDefinition | null,
 ): Promise<void> {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) return;
 
-  const userId = toUserId(session.user.id);
+  const userId = session.user.id;
 
   if (data === null) {
     await structuredPlaylistsDefinitionDbRepository.delete(userId, accId);

--- a/apps/www/src/lib/user.ts
+++ b/apps/www/src/lib/user.ts
@@ -1,11 +1,7 @@
 import { headers } from "next/headers";
-import {
-  type AccountId,
-  type ProviderAccountId,
-  toUserId,
-  type UserId,
-} from "@/entities/ids";
+import type { AccountId, ProviderAccountId, UserId } from "@/entities/ids";
 import { auth } from "@/lib/auth";
+import { getSession } from "@/repository/auth/session";
 import { userDbRepository } from "@/repository/db/user/repository";
 
 import "server-only";
@@ -77,14 +73,10 @@ export async function fetchProviderProfiles(
 }
 
 export async function getSessionUser(): Promise<User | null> {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
+  const session = await getSession();
   if (!session) return null;
 
-  const accounts = await userDbRepository.findAccountsByUserId(
-    toUserId(session.user.id),
-  );
+  const accounts = await userDbRepository.findAccountsByUserId(session.user.id);
 
   const providers: UserProvider[] = accounts.map((a) => ({
     id: a.id,
@@ -94,7 +86,7 @@ export async function getSessionUser(): Promise<User | null> {
   }));
 
   return {
-    id: toUserId(session.user.id),
+    id: session.user.id,
     name: session.user.name,
     email: session.user.email,
     image: session.user.image ?? null,

--- a/apps/www/src/presentation/pages/layouts/header/index.tsx
+++ b/apps/www/src/presentation/pages/layouts/header/index.tsx
@@ -1,7 +1,6 @@
 import type { WithT } from "i18next";
-import { headers } from "next/headers";
 import { UserMenu } from "@/features/user-menu/components/user-menu";
-import { auth } from "@/lib/auth";
+import { getSession } from "@/repository/auth/session";
 import { GetStartedButton } from "./get-started-button";
 import { HeaderNavSection } from "./header-nav-section";
 import { HeaderSearchBox } from "./header-search-box";
@@ -9,7 +8,7 @@ import { HeaderSearchBox } from "./header-search-box";
 export type HeaderProps = WithT & { lang: string };
 
 export async function Header(_props: HeaderProps) {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   const user = session?.user
     ? { name: session.user.name, image: session.user.image ?? null }
     : null;

--- a/apps/www/src/repository/auth/session.ts
+++ b/apps/www/src/repository/auth/session.ts
@@ -1,0 +1,36 @@
+import { headers } from "next/headers";
+import { cache } from "react";
+import type { UserId } from "@/entities/ids";
+import { toUserId } from "@/entities/ids";
+import { auth, type Session } from "@/lib/auth";
+
+import "server-only";
+
+export type AppSession = Omit<Session, "session" | "user"> & {
+  session: Omit<Session["session"], "userId"> & {
+    userId: UserId;
+  };
+  user: Omit<Session["user"], "id"> & {
+    id: UserId;
+  };
+};
+
+export const getSession = cache(async (): Promise<AppSession | null> => {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) return null;
+
+  return {
+    ...session,
+    session: {
+      ...session.session,
+      userId: toUserId(session.session.userId),
+    },
+    user: {
+      ...session.user,
+      id: toUserId(session.user.id),
+    },
+  };
+});

--- a/apps/www/src/usecase/actions/dismiss-backend-jobs.ts
+++ b/apps/www/src/usecase/actions/dismiss-backend-jobs.ts
@@ -1,15 +1,14 @@
 "use server";
 
 import { and, eq, inArray } from "drizzle-orm";
-import { headers } from "next/headers";
-import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { job } from "@/lib/db/schema";
+import { getSession } from "@/repository/auth/session";
 
 export async function dismissBackendJobs(jobIds: string[]): Promise<void> {
   if (jobIds.length === 0) return;
 
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) return;
 
   await db

--- a/apps/www/src/usecase/actions/get-backend-jobs.ts
+++ b/apps/www/src/usecase/actions/get-backend-jobs.ts
@@ -6,16 +6,15 @@ import {
   JobStatus,
 } from "@playlistwizard/playlist-action-job";
 import { and, eq, gte, inArray, or } from "drizzle-orm";
-import { headers } from "next/headers";
 import { safeParse } from "valibot";
-import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { job } from "@/lib/db/schema";
+import { getSession } from "@/repository/auth/session";
 
 const DISPLAY_RETENTION_MS = 10 * 1000;
 
 export async function getBackendJobs(): Promise<BackendJob[]> {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) return [];
 
   const userId = session.user.id;


### PR DESCRIPTION
## Summary
- Add a repository-level cached auth session helper that brands Better Auth user IDs
- Replace direct server-side getSession calls with the shared helper
- Remove repeated user ID branding at call sites

## Verification
- pnpm -F @playlistwizard/www exec tsc --noEmit
- pnpm exec biome check apps/www/src/repository/auth/session.ts apps/www/src/lib/user.ts apps/www/src/features/structured-playlists-definition/actions.ts apps/www/src/presentation/pages/layouts/header/index.tsx apps/www/src/features/pinned-playlists/actions.ts apps/www/src/features/feedback/actions.ts apps/www/src/usecase/actions/get-backend-jobs.ts apps/www/src/usecase/actions/dismiss-backend-jobs.ts