### PR TITLE
Add developer feature toggle console

### DIFF
--- a/apps/www/scripts/set-developer-user.ts
+++ b/apps/www/scripts/set-developer-user.ts
@@ -1,0 +1,68 @@
+/**
+ * 指定ユーザーの developer 権限を切り替えるスクリプト
+ *
+ * Usage:
+ *   pnpm --filter @playlistwizard/www tsx scripts/set-developer-user.ts <userIdOrEmail> [true|false]
+ *
+ * Example:
+ *   pnpm --filter @playlistwizard/www tsx scripts/set-developer-user.ts developer@example.com true
+ */
+
+import { resolve } from "node:path";
+import { config } from "dotenv";
+
+config({ path: resolve(__dirname, "../.env") });
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import * as schema from "../src/lib/db/schema";
+
+const [userIdOrEmail, enabledArg = "true"] = process.argv.slice(2);
+
+if (!userIdOrEmail || !["true", "false"].includes(enabledArg)) {
+  console.error(
+    "Usage: tsx scripts/set-developer-user.ts <userIdOrEmail> [true|false]",
+  );
+  process.exit(1);
+}
+
+const enabled = enabledArg === "true";
+
+async function main() {
+  const client = postgres(process.env.DATABASE_URL!, { prepare: false });
+  const db = drizzle(client, { schema });
+
+  const where = userIdOrEmail.includes("@")
+    ? eq(schema.user.email, userIdOrEmail)
+    : eq(schema.user.id, userIdOrEmail);
+
+  const rows = await db
+    .update(schema.user)
+    .set({ isDeveloper: enabled })
+    .where(where)
+    .returning({
+      id: schema.user.id,
+      email: schema.user.email,
+      isDeveloper: schema.user.isDeveloper,
+    });
+
+  if (rows.length === 0) {
+    console.error(`User not found: ${userIdOrEmail}`);
+    await client.end();
+    process.exit(1);
+  }
+
+  const user = rows[0];
+  console.log(
+    `Set is_developer=${user.isDeveloper} for ${user.email} (${user.id})`,
+  );
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/www/src/app/[lang]/(with-nav)/dev/console/page.tsx
+++ b/apps/www/src/app/[lang]/(with-nav)/dev/console/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { DevConsoleView } from "@/features/dev-console/view";
+import { requireDeveloperPageUser } from "@/lib/developer";
+
+export const metadata: Metadata = {
+  title: "Dev Console - PlaylistWizard",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default async function ({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  const user = await requireDeveloperPageUser(lang);
+
+  return <DevConsoleView user={user} />;
+}

--- a/apps/www/src/components/makeLocalizedUrl.test.ts
+++ b/apps/www/src/components/makeLocalizedUrl.test.ts
@@ -17,4 +17,8 @@ describe("makeLocalizedUrl", () => {
   it("should handle empty paths correctly", () => {
     expect(makeLocalizedUrl("en", "")).toBe("/en/");
   });
+
+  it("should not double-prefix already localized paths", () => {
+    expect(makeLocalizedUrl("en", "/en/about")).toBe("/en/about");
+  });
 });

--- a/apps/www/src/components/makeLocalizedUrl.ts
+++ b/apps/www/src/components/makeLocalizedUrl.ts
@@ -3,6 +3,14 @@ export function makeLocalizedUrl(lang: string, path: string): string {
     return `/${lang}`;
   }
 
+  if (
+    path === `/${lang}` ||
+    path.startsWith(`/${lang}/`) ||
+    path.startsWith(`/${lang}?`)
+  ) {
+    return path;
+  }
+
   if (!path.startsWith("/")) {
     return `/${lang}/${path}`;
   }

--- a/apps/www/src/components/ui/switch.tsx
+++ b/apps/www/src/components/ui/switch.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Switch as SwitchPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/cn";
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "cursor-pointer",
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=sm]:h-3.5 data-[size=default]:w-8 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/apps/www/src/constants/urls.ts
+++ b/apps/www/src/constants/urls.ts
@@ -29,6 +29,9 @@ export const structuredPlaylistsEditor = (lang: string) =>
 
 export const settings = (lang: string) => makeLocalizedUrl(lang, "/settings");
 
+export const devConsole = (lang: string) =>
+  makeLocalizedUrl(lang, "/dev/console");
+
 export const terms = (lang: string) => makeLocalizedUrl(lang, "/terms");
 export const privacy = (lang: string) => makeLocalizedUrl(lang, "/privacy");
 

--- a/apps/www/src/features/dev-console/actions.test.ts
+++ b/apps/www/src/features/dev-console/actions.test.ts
@@ -1,0 +1,77 @@
+import { revalidatePath } from "next/cache";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requireDeveloperActionUser } from "@/lib/developer";
+import { FeatureFlagName } from "@/lib/feature-flags";
+import { featureFlagDbRepository } from "@/repository/db/feature-flag/repository";
+import { setFeatureFlagForCurrentDeveloper } from "./actions";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/developer", () => ({
+  requireDeveloperActionUser: vi.fn(),
+}));
+
+vi.mock("@/repository/db/feature-flag/repository", () => ({
+  featureFlagDbRepository: {
+    insert: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+function createFormData(flagName: string, enabled: boolean) {
+  const formData = new FormData();
+  formData.set("flagName", flagName);
+  formData.set("enabled", String(enabled));
+  return formData;
+}
+
+describe("setFeatureFlagForCurrentDeveloper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDeveloperActionUser).mockResolvedValue({
+      id: "user-1" as never,
+      name: "Developer",
+      email: "developer@example.com",
+    });
+    vi.mocked(featureFlagDbRepository.insert).mockResolvedValue(undefined);
+    vi.mocked(featureFlagDbRepository.delete).mockResolvedValue(undefined);
+    vi.mocked(revalidatePath).mockReturnValue(undefined);
+  });
+
+  it("enables a valid feature flag for the current developer", async () => {
+    await setFeatureFlagForCurrentDeveloper(
+      createFormData(FeatureFlagName.playlistActionJob, true),
+    );
+
+    expect(requireDeveloperActionUser).toHaveBeenCalledOnce();
+    expect(featureFlagDbRepository.insert).toHaveBeenCalledWith(
+      FeatureFlagName.playlistActionJob,
+      "user-1",
+    );
+    expect(featureFlagDbRepository.delete).not.toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith("/[lang]/dev/console", "page");
+  });
+
+  it("disables a valid feature flag for the current developer", async () => {
+    await setFeatureFlagForCurrentDeveloper(
+      createFormData(FeatureFlagName.playlistActionJob, false),
+    );
+
+    expect(featureFlagDbRepository.delete).toHaveBeenCalledWith(
+      FeatureFlagName.playlistActionJob,
+      "user-1",
+    );
+    expect(featureFlagDbRepository.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown feature flag names", async () => {
+    await expect(
+      setFeatureFlagForCurrentDeveloper(createFormData("unknown", true)),
+    ).rejects.toThrow("Invalid feature flag name");
+
+    expect(featureFlagDbRepository.insert).not.toHaveBeenCalled();
+    expect(featureFlagDbRepository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/www/src/features/dev-console/actions.ts
+++ b/apps/www/src/features/dev-console/actions.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireDeveloperActionUser } from "@/lib/developer";
+import { FeatureFlagName } from "@/lib/feature-flags";
+import { featureFlagDbRepository } from "@/repository/db/feature-flag/repository";
+
+const validFlagNames = new Set<string>(Object.values(FeatureFlagName));
+
+function parseFeatureFlagName(
+  value: FormDataEntryValue | null,
+): FeatureFlagName {
+  if (typeof value === "string" && validFlagNames.has(value)) {
+    return value as FeatureFlagName;
+  }
+
+  throw new Error("Invalid feature flag name");
+}
+
+export async function setFeatureFlagForCurrentDeveloper(
+  formData: FormData,
+): Promise<void> {
+  const user = await requireDeveloperActionUser();
+  const flagName = parseFeatureFlagName(formData.get("flagName"));
+  const enabled = formData.get("enabled") === "true";
+
+  if (enabled) {
+    await featureFlagDbRepository.insert(flagName, user.id);
+  } else {
+    await featureFlagDbRepository.delete(flagName, user.id);
+  }
+
+  revalidatePath("/[lang]/dev/console", "page");
+}

--- a/apps/www/src/features/dev-console/feature-flag-toggle.tsx
+++ b/apps/www/src/features/dev-console/feature-flag-toggle.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Switch } from "@/components/ui/switch";
+import type { FeatureFlagName } from "@/lib/feature-flags";
+import { setFeatureFlagForCurrentDeveloper } from "./actions";
+
+type FeatureFlagToggleProps = {
+  flagName: FeatureFlagName;
+  enabled: boolean;
+};
+
+export function FeatureFlagToggle({
+  flagName,
+  enabled,
+}: FeatureFlagToggleProps) {
+  const [checked, setChecked] = useState(enabled);
+  const [isPending, startTransition] = useTransition();
+
+  function handleCheckedChange(nextChecked: boolean) {
+    setChecked(nextChecked);
+
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set("flagName", flagName);
+      formData.set("enabled", String(nextChecked));
+
+      try {
+        await setFeatureFlagForCurrentDeveloper(formData);
+      } catch {
+        setChecked(!nextChecked);
+      }
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-end gap-3">
+      <span className="min-w-7 text-right text-gray-400 text-sm">
+        {checked ? "On" : "Off"}
+      </span>
+      <Switch
+        aria-label={`Toggle ${flagName}`}
+        checked={checked}
+        disabled={isPending}
+        onCheckedChange={handleCheckedChange}
+      />
+    </div>
+  );
+}

--- a/apps/www/src/features/dev-console/view.tsx
+++ b/apps/www/src/features/dev-console/view.tsx
@@ -1,0 +1,94 @@
+import { Badge } from "@/components/ui/badge";
+import type { DeveloperUser } from "@/lib/developer";
+import { FEATURE_FLAGS, type FeatureFlagName } from "@/lib/feature-flags";
+import { featureFlagDbRepository } from "@/repository/db/feature-flag/repository";
+import { FeatureFlagToggle } from "./feature-flag-toggle";
+
+type DevConsoleViewProps = {
+  user: DeveloperUser;
+};
+
+export async function DevConsoleView({ user }: DevConsoleViewProps) {
+  const enabledFlags = new Set(
+    await featureFlagDbRepository.findEnabledFlagsByUserId(user.id),
+  );
+  const flags = Object.entries(FEATURE_FLAGS) as [
+    FeatureFlagName,
+    (typeof FEATURE_FLAGS)[FeatureFlagName],
+  ][];
+
+  return (
+    <main className="min-h-screen">
+      <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+        <header className="space-y-2">
+          <p className="font-medium text-pink-400 text-sm">Developer</p>
+          <h1 className="font-bold text-3xl text-white">Dev Console</h1>
+          <p className="text-gray-400">
+            Manage feature toggle allowlist entries for {user.email}.
+          </p>
+        </header>
+
+        <section className="overflow-hidden rounded-lg border border-gray-800 bg-gray-950/60">
+          <div className="grid grid-cols-[1fr_auto] gap-4 border-gray-800 border-b px-5 py-4 sm:grid-cols-[1fr_auto_auto_auto]">
+            <span className="font-medium text-gray-300 text-sm">Flag</span>
+            <span className="hidden font-medium text-gray-300 text-sm sm:block">
+              Config
+            </span>
+            <span className="hidden font-medium text-gray-300 text-sm sm:block">
+              Allowlist
+            </span>
+            <span className="font-medium text-gray-300 text-sm">Toggle</span>
+          </div>
+
+          <div className="divide-y divide-gray-800">
+            {flags.map(([name, config]) => {
+              const isAllowlisted = enabledFlags.has(name);
+
+              return (
+                <div
+                  key={name}
+                  className="grid grid-cols-[1fr_auto] items-center gap-4 px-5 py-4 sm:grid-cols-[1fr_auto_auto_auto]"
+                >
+                  <div className="min-w-0 space-y-1">
+                    <div>
+                      <h2 className="truncate font-semibold text-white">
+                        {name}
+                      </h2>
+                      {config.description ? (
+                        <p className="text-gray-500 text-sm">
+                          {config.description}
+                        </p>
+                      ) : null}
+                    </div>
+                    <p className="text-gray-500 text-sm sm:hidden">
+                      config {config.enabled ? "enabled" : "disabled"} / rollout{" "}
+                      {Math.round(config.rollout * 100)}%
+                    </p>
+                  </div>
+
+                  <div className="hidden items-center gap-2 sm:flex">
+                    <Badge variant={config.enabled ? "default" : "secondary"}>
+                      {config.enabled ? "enabled" : "disabled"}
+                    </Badge>
+                    <span className="text-gray-400 text-sm">
+                      {Math.round(config.rollout * 100)}%
+                    </span>
+                  </div>
+
+                  <Badge
+                    className="hidden sm:inline-flex"
+                    variant={isAllowlisted ? "default" : "outline"}
+                  >
+                    {isAllowlisted ? "on" : "off"}
+                  </Badge>
+
+                  <FeatureFlagToggle flagName={name} enabled={isAllowlisted} />
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/www/src/lib/auth.ts
+++ b/apps/www/src/lib/auth.ts
@@ -29,6 +29,15 @@ export const auth = betterAuth({
   },
   user: {
     deleteUser: { enabled: true },
+    additionalFields: {
+      isDeveloper: {
+        type: "boolean",
+        fieldName: "is_developer",
+        input: false,
+        required: false,
+        defaultValue: false,
+      },
+    },
   },
   plugins: [nextCookies()],
 });

--- a/apps/www/src/lib/developer.ts
+++ b/apps/www/src/lib/developer.ts
@@ -1,0 +1,59 @@
+import { eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import { urls } from "@/constants";
+import { toUserId, type UserId } from "@/entities/ids";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { user } from "@/lib/db/schema";
+
+import "server-only";
+
+export type DeveloperUser = {
+  id: UserId;
+  name: string;
+  email: string;
+};
+
+export async function requireDeveloperPageUser(
+  lang: string,
+): Promise<DeveloperUser> {
+  const session = await auth.api.getSession({ headers: await headers() });
+
+  if (!session) {
+    redirect(urls.signIn(lang, urls.devConsole(lang)));
+  }
+
+  if (!(await isDeveloper(session.user.id))) {
+    notFound();
+  }
+
+  return {
+    id: toUserId(session.user.id),
+    name: session.user.name,
+    email: session.user.email,
+  };
+}
+
+export async function requireDeveloperActionUser(): Promise<DeveloperUser> {
+  const session = await auth.api.getSession({ headers: await headers() });
+
+  if (!session || !(await isDeveloper(session.user.id))) {
+    throw new Error("Developer access required");
+  }
+
+  return {
+    id: toUserId(session.user.id),
+    name: session.user.name,
+    email: session.user.email,
+  };
+}
+
+async function isDeveloper(userId: string): Promise<boolean> {
+  const row = await db.query.user.findFirst({
+    columns: { isDeveloper: true },
+    where: eq(user.id, userId),
+  });
+
+  return row?.isDeveloper ?? false;
+}

--- a/apps/www/src/lib/feature-flag-evaluator.test.ts
+++ b/apps/www/src/lib/feature-flag-evaluator.test.ts
@@ -8,14 +8,10 @@ import { FeatureFlagName } from "./feature-flags";
 
 const mockFlags = (overrides: Partial<featureFlags.FeatureFlagConfig>) => {
   vi.spyOn(featureFlags, "FEATURE_FLAGS", "get").mockReturnValue({
-    [FeatureFlagName.temp]: {
-      enabled: true,
-      rollout: 0,
-      ...overrides,
-    },
     [FeatureFlagName.playlistActionJob]: {
       enabled: true,
       rollout: 0,
+      ...overrides,
     },
   });
 };
@@ -31,13 +27,17 @@ describe("evaluateFeatureFlag", () => {
     mockFlags({ enabled: false, rollout: 1.0 });
     expect(
       evaluateFeatureFlag(
-        FeatureFlagName.temp,
+        FeatureFlagName.playlistActionJob,
         "user1",
-        new Set([FeatureFlagName.temp]),
+        new Set([FeatureFlagName.playlistActionJob]),
       ),
     ).toBe(false);
     expect(
-      evaluateFeatureFlag(FeatureFlagName.temp, "user2", emptyEnabledFlags),
+      evaluateFeatureFlag(
+        FeatureFlagName.playlistActionJob,
+        "user2",
+        emptyEnabledFlags,
+      ),
     ).toBe(false);
   });
 
@@ -45,9 +45,9 @@ describe("evaluateFeatureFlag", () => {
     mockFlags({ enabled: true, rollout: 0 });
     expect(
       evaluateFeatureFlag(
-        FeatureFlagName.temp,
+        FeatureFlagName.playlistActionJob,
         "user1",
-        new Set([FeatureFlagName.temp]),
+        new Set([FeatureFlagName.playlistActionJob]),
       ),
     ).toBe(true);
   });
@@ -55,39 +55,59 @@ describe("evaluateFeatureFlag", () => {
   it("enabledFlags does not have flag, rollout: 0 → false", () => {
     mockFlags({ enabled: true, rollout: 0 });
     expect(
-      evaluateFeatureFlag(FeatureFlagName.temp, "user1", emptyEnabledFlags),
+      evaluateFeatureFlag(
+        FeatureFlagName.playlistActionJob,
+        "user1",
+        emptyEnabledFlags,
+      ),
     ).toBe(false);
   });
 
   it("rollout: 1.0 → true for any userId", () => {
     mockFlags({ enabled: true, rollout: 1.0 });
     expect(
-      evaluateFeatureFlag(FeatureFlagName.temp, "user1", emptyEnabledFlags),
+      evaluateFeatureFlag(
+        FeatureFlagName.playlistActionJob,
+        "user1",
+        emptyEnabledFlags,
+      ),
     ).toBe(true);
     expect(
-      evaluateFeatureFlag(FeatureFlagName.temp, "user2", emptyEnabledFlags),
+      evaluateFeatureFlag(
+        FeatureFlagName.playlistActionJob,
+        "user2",
+        emptyEnabledFlags,
+      ),
     ).toBe(true);
     expect(
-      evaluateFeatureFlag(FeatureFlagName.temp, "anyuser", emptyEnabledFlags),
+      evaluateFeatureFlag(
+        FeatureFlagName.playlistActionJob,
+        "anyuser",
+        emptyEnabledFlags,
+      ),
     ).toBe(true);
   });
 
   it("userId: undefined → false (unauthenticated)", () => {
     mockFlags({ enabled: true, rollout: 1.0 });
     expect(
-      evaluateFeatureFlag(FeatureFlagName.temp, undefined, emptyEnabledFlags),
+      evaluateFeatureFlag(
+        FeatureFlagName.playlistActionJob,
+        undefined,
+        emptyEnabledFlags,
+      ),
     ).toBe(false);
   });
 
   it("same userId+flagName always returns same result (deterministic)", () => {
     mockFlags({ enabled: true, rollout: 0.5 });
     const result1 = evaluateFeatureFlag(
-      FeatureFlagName.temp,
+      FeatureFlagName.playlistActionJob,
       "stableUser",
       emptyEnabledFlags,
     );
     const result2 = evaluateFeatureFlag(
-      FeatureFlagName.temp,
+      FeatureFlagName.playlistActionJob,
       "stableUser",
       emptyEnabledFlags,
     );
@@ -102,7 +122,7 @@ describe("evaluateAllFeatureFlags", () => {
 
   it("returns a record for all flags", () => {
     const result = evaluateAllFeatureFlags("user1", emptyEnabledFlags);
-    expect(result).toHaveProperty(FeatureFlagName.temp);
+    expect(result).toHaveProperty(FeatureFlagName.playlistActionJob);
   });
 
   it("userId: undefined → all false", () => {

--- a/apps/www/src/lib/feature-flags.ts
+++ b/apps/www/src/lib/feature-flags.ts
@@ -1,10 +1,10 @@
 export type FeatureFlagConfig = {
   enabled: boolean;
+  description?: string;
   rollout: number; // 0.0〜1.0
 };
 
 export const FeatureFlagName = {
-  temp: "temp",
   playlistActionJob: "playlistActionJob",
 } as const;
 
@@ -12,12 +12,10 @@ export type FeatureFlagName =
   (typeof FeatureFlagName)[keyof typeof FeatureFlagName];
 
 export const FEATURE_FLAGS: Record<FeatureFlagName, FeatureFlagConfig> = {
-  [FeatureFlagName.temp]: {
-    enabled: true,
-    rollout: 0,
-  },
   [FeatureFlagName.playlistActionJob]: {
     enabled: true,
+    description:
+      "Enable the server-side playlist action job for process queueing playlist actions.",
     rollout: 0,
   },
 };

--- a/apps/www/src/lib/user.ts
+++ b/apps/www/src/lib/user.ts
@@ -22,6 +22,7 @@ export interface User {
   name: string;
   email: string;
   image: string | null;
+  isDeveloper: boolean;
   providers: UserProvider[];
 }
 
@@ -98,6 +99,7 @@ export async function getSessionUser(): Promise<User | null> {
     name: session.user.name,
     email: session.user.email,
     image: session.user.image ?? null,
+    isDeveloper: session.user.isDeveloper ?? false,
     providers,
   };
 }

--- a/apps/www/src/proxy.ts
+++ b/apps/www/src/proxy.ts
@@ -16,6 +16,14 @@ const protectedPrefixes = [
   "/structured-playlists/editor",
   "/settings",
   "/search",
+  "/dev/console",
+];
+
+const accountScopedPrefixes = [
+  "/playlists",
+  "/structured-playlists/editor",
+  "/settings",
+  "/search",
 ];
 
 acceptLanguage.languages(supportedLangs);
@@ -55,7 +63,11 @@ export async function proxy(req: NextRequest) {
     );
   }
 
-  if (isProtected && sessionCookie) {
+  const isAccountScoped = accountScopedPrefixes.some((p) =>
+    pathWithoutLang.startsWith(p),
+  );
+
+  if (isProtected && isAccountScoped && sessionCookie) {
     const accountId = req.nextUrl.searchParams.get(searchParams.focusedAccount);
     let accountIds: Awaited<ReturnType<typeof getLinkedAccountIds>>;
     try {

--- a/apps/www/src/repository/db/feature-flag/repository.test.ts
+++ b/apps/www/src/repository/db/feature-flag/repository.test.ts
@@ -35,14 +35,14 @@ describe("FeatureFlagDbRepository", () => {
   describe("findEnabledFlagsByUserId", () => {
     it("returns enabled flag names for the given userId", async () => {
       const db = createMockDb();
-      const rows = [{ flagName: FeatureFlagName.temp }];
+      const rows = [{ flagName: FeatureFlagName.playlistActionJob }];
       const whereMock = vi.fn().mockResolvedValue(rows);
       db._mocks.fromMock.mockReturnValue({ where: whereMock });
 
       const repo = new FeatureFlagDbRepository(db as never);
       const result = await repo.findEnabledFlagsByUserId("user-1");
 
-      expect(result).toEqual([FeatureFlagName.temp]);
+      expect(result).toEqual([FeatureFlagName.playlistActionJob]);
       expect(db.select).toHaveBeenCalledOnce();
       expect(whereMock).toHaveBeenCalledWith(expect.anything());
     });
@@ -51,7 +51,7 @@ describe("FeatureFlagDbRepository", () => {
       const db = createMockDb();
       const rows = [
         { flagName: "unknownFlag" },
-        { flagName: FeatureFlagName.temp },
+        { flagName: FeatureFlagName.playlistActionJob },
       ];
       const whereMock = vi.fn().mockResolvedValue(rows);
       db._mocks.fromMock.mockReturnValue({ where: whereMock });
@@ -59,7 +59,7 @@ describe("FeatureFlagDbRepository", () => {
       const repo = new FeatureFlagDbRepository(db as never);
       const result = await repo.findEnabledFlagsByUserId("user-1");
 
-      expect(result).toEqual([FeatureFlagName.temp]);
+      expect(result).toEqual([FeatureFlagName.playlistActionJob]);
     });
 
     it("returns empty array when no rows found", async () => {
@@ -90,12 +90,12 @@ describe("FeatureFlagDbRepository", () => {
       const db = createMockDb();
       const repo = new FeatureFlagDbRepository(db as never);
 
-      await repo.insert(FeatureFlagName.temp, "user-1");
+      await repo.insert(FeatureFlagName.playlistActionJob, "user-1");
 
       expect(db.insert).toHaveBeenCalledOnce();
       expect(db._mocks.valuesMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          flagName: FeatureFlagName.temp,
+          flagName: FeatureFlagName.playlistActionJob,
           userId: "user-1",
         }),
       );
@@ -109,9 +109,9 @@ describe("FeatureFlagDbRepository", () => {
       );
       const repo = new FeatureFlagDbRepository(db as never);
 
-      await expect(repo.insert(FeatureFlagName.temp, "user-1")).rejects.toThrow(
-        "DB error",
-      );
+      await expect(
+        repo.insert(FeatureFlagName.playlistActionJob, "user-1"),
+      ).rejects.toThrow("DB error");
     });
   });
 
@@ -120,7 +120,7 @@ describe("FeatureFlagDbRepository", () => {
       const db = createMockDb();
       const repo = new FeatureFlagDbRepository(db as never);
 
-      await repo.delete(FeatureFlagName.temp, "user-1");
+      await repo.delete(FeatureFlagName.playlistActionJob, "user-1");
 
       expect(db.delete).toHaveBeenCalledOnce();
       expect(db._mocks.whereMock).toHaveBeenCalledWith(expect.anything());
@@ -131,9 +131,9 @@ describe("FeatureFlagDbRepository", () => {
       db._mocks.whereMock.mockRejectedValue(new Error("DB error"));
       const repo = new FeatureFlagDbRepository(db as never);
 
-      await expect(repo.delete(FeatureFlagName.temp, "user-1")).rejects.toThrow(
-        "DB error",
-      );
+      await expect(
+        repo.delete(FeatureFlagName.playlistActionJob, "user-1"),
+      ).rejects.toThrow("DB error");
     });
   });
 });

--- a/packages/db/drizzle/0015_add_user_is_developer.sql
+++ b/packages/db/drizzle/0015_add_user_is_developer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "is_developer" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1774100000000,
       "tag": "0014_add_job_dismissed",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1774300000000,
+      "tag": "0015_add_user_is_developer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -24,6 +24,7 @@ export const user = pgTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
+  isDeveloper: boolean("is_developer").default(false).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()


### PR DESCRIPTION
## Summary
- add a developer-only /dev/console page for toggling the current user's feature flag allowlist
- add is_developer user access control and migration
- add a shadcn-style Switch UI and tests for feature flag management

## Verification
- pnpm -F @playlistwizard/www exec tsc --noEmit
- pnpm -F @playlistwizard/www test src/repository/db/feature-flag/repository.test.ts src/features/dev-console/actions.test.ts src/lib/feature-flag-evaluator.test.ts
- pnpm -w exec biome check apps/www/src/lib/feature-flag-evaluator.test.ts apps/www/src/repository/db/feature-flag/repository.test.ts apps/www/src/components/ui/switch.tsx apps/www/src/features/dev-console/actions.test.ts apps/www/src/features/dev-console/view.tsx apps/www/src/features/dev-console/feature-flag-toggle.tsx