### PR TITLE
Fix playlist action loading before extract dialog opens

### DIFF
--- a/apps/www/src/features/playlist/components/actions/extract-action.tsx
+++ b/apps/www/src/features/playlist/components/actions/extract-action.tsx
@@ -42,6 +42,7 @@ function useExtractAction(t: TFunction) {
   const history = useHistory();
   const [focusedAccount] = useFocusedAccount();
   const [isOpen, setIsOpen] = useState(false);
+  const [isOpening, setIsOpening] = useState(false);
   const [targetId, setTargetId] = useState<PlaylistId | null>(null);
   const [allowDuplicates, setAllowDuplicates] = useState(false);
 
@@ -97,11 +98,19 @@ function useExtractAction(t: TFunction) {
   );
 
   async function handleOnOpen(open: boolean) {
-    if (open) {
-      await refreshItems(selectedPlaylists);
+    if (!open) {
+      setIsOpen(false);
+      setIsOpening(false);
+      return;
     }
 
-    setIsOpen(open);
+    setIsOpening(true);
+    try {
+      await refreshItems(selectedPlaylists);
+      setIsOpen(true);
+    } finally {
+      setIsOpening(false);
+    }
   }
 
   async function handleExtract() {
@@ -196,6 +205,7 @@ function useExtractAction(t: TFunction) {
 
   return {
     isOpen,
+    isOpening,
     handleOnOpen,
     targetId,
     setTargetId,
@@ -217,6 +227,7 @@ export function ExtractAction({
 }: PlaylistActionComponentProps) {
   const {
     isOpen,
+    isOpening,
     handleOnOpen,
     targetId,
     setTargetId,
@@ -232,7 +243,7 @@ export function ExtractAction({
   return (
     <Dialog open={isOpen} onOpenChange={handleOnOpen}>
       <DialogTrigger asChild>
-        <PlaylistActionButton disabled={disabled}>
+        <PlaylistActionButton disabled={disabled} isLoading={isOpening}>
           <Icon className="mr-2 h-4 w-4" />
           {label}
         </PlaylistActionButton>

--- a/apps/www/src/features/playlist/components/playlist-action-button.tsx
+++ b/apps/www/src/features/playlist/components/playlist-action-button.tsx
@@ -1,24 +1,43 @@
 import { Button, type ButtonProps, cn } from "@playlistwizard/ui";
+import { Loader2 } from "lucide-react";
 import type { PropsWithChildren } from "react";
 
-type PlaylistActionButtonProps = PropsWithChildren<ButtonProps>;
+type PlaylistActionButtonProps = PropsWithChildren<
+  ButtonProps & {
+    isLoading?: boolean;
+  }
+>;
 
 export function PlaylistActionButton({
   children,
   className,
+  disabled,
+  isLoading = false,
   ...buttonProps
 }: PlaylistActionButtonProps) {
   return (
     <Button
       variant="outline"
       size="sm"
+      disabled={disabled || isLoading}
+      aria-busy={isLoading || undefined}
       className={cn(
-        "border border-gray-700 bg-background text-white shadow-xs hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700",
+        "relative border border-gray-700 bg-background text-white shadow-xs hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700",
         className,
       )}
       {...buttonProps}
     >
-      {children}
+      {isLoading ? (
+        <Loader2 className="absolute h-4 w-4 animate-spin" aria-hidden="true" />
+      ) : null}
+      <span
+        className={cn(
+          "inline-flex items-center",
+          isLoading ? "opacity-0" : undefined,
+        )}
+      >
+        {children}
+      </span>
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- Add a loading state to PlaylistActionButton while pre-dialog work is running.
- Show that loading state when Extract is fetching Playlist Items before opening the modal.
- Keep the trigger disabled and marked busy during the opening fetch.

## Validation
- pnpm format
- pnpm lint
- pnpm build:packages
- pnpm -F @playlistwizard/www exec tsc --noEmit was attempted, but the app currently fails on existing PageProps/LayoutProps generated type and image module resolution errors unrelated to this change.