### PR TITLE
Extract API playlist domain primitives into core

### DIFF
--- a/.changeset/bright-buckets-reflect.md
+++ b/.changeset/bright-buckets-reflect.md
@@ -1,0 +1,5 @@
+---
+"@playlistwizard/core": patch
+---
+
+feat: Export playlist domain entities and action planning utilities

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hono/valibot-validator": "^0.6.1",
+    "@playlistwizard/core": "workspace:*",
     "@playlistwizard/db": "workspace:*",
     "@playlistwizard/playlist-action-job": "workspace:*",
     "@sentry/cloudflare": "^10.40.0",

--- a/apps/api/src/infrastructure/accounts/drizzle-account-access.ts
+++ b/apps/api/src/infrastructure/accounts/drizzle-account-access.ts
@@ -1,3 +1,9 @@
+import {
+  toAccountId,
+  toProviderAccountId,
+  toUserId,
+} from "@playlistwizard/core/ids";
+import { toProvider } from "@playlistwizard/core/provider";
 import * as schema from "@playlistwizard/db";
 import { and, eq } from "drizzle-orm";
 import type { AccountAccess } from "../../usecase/playlist-actions/ports";
@@ -6,7 +12,9 @@ import type { Db } from "../db/connection";
 export class DrizzleAccountAccess implements AccountAccess {
   constructor(private readonly db: Db) {}
 
-  async findExecutionAccount(input: { accountId: string; userId: string }) {
+  async findExecutionAccount(
+    input: Parameters<AccountAccess["findExecutionAccount"]>[0],
+  ) {
     const account = await this.db.query.account.findFirst({
       where: and(
         eq(schema.account.id, input.accountId),
@@ -17,10 +25,10 @@ export class DrizzleAccountAccess implements AccountAccess {
     if (!account) return null;
 
     return {
-      id: account.id,
-      providerAccountId: account.accountId,
-      providerId: account.providerId,
-      userId: account.userId,
+      id: toAccountId(account.id),
+      providerAccountId: toProviderAccountId(account.accountId),
+      providerId: toProvider(account.providerId),
+      userId: toUserId(account.userId),
     };
   }
 }

--- a/apps/api/src/infrastructure/playlist-action-jobs/drizzle-playlist-action-job-repository.ts
+++ b/apps/api/src/infrastructure/playlist-action-jobs/drizzle-playlist-action-job-repository.ts
@@ -1,3 +1,4 @@
+import { toAccountId, toUserId } from "@playlistwizard/core/ids";
 import * as schema from "@playlistwizard/db";
 import {
   JobStatus,
@@ -298,7 +299,7 @@ const toAddStepRow = (step: AddPlaylistItemStepDraft) => ({
 const toJobRecord = (
   job: typeof schema.job.$inferSelect,
 ): PlaylistActionJobRecord => ({
-  accountId: job.accountId,
+  accountId: toAccountId(job.accountId),
   completeSteps: job.completeSteps,
   createdAt: job.createdAt,
   error: job.error,
@@ -307,7 +308,7 @@ const toJobRecord = (
   totalSteps: job.totalSteps,
   type: job.type,
   updatedAt: job.updatedAt,
-  userId: job.userId,
+  userId: toUserId(job.userId),
 });
 
 const toStepRecord = (

--- a/apps/api/src/presentation/http/playlist-action-jobs/routes.ts
+++ b/apps/api/src/presentation/http/playlist-action-jobs/routes.ts
@@ -1,4 +1,5 @@
 import { vValidator } from "@hono/valibot-validator";
+import { toAccountId, toUserId } from "@playlistwizard/core/ids";
 import { createJobRequestSchema } from "@playlistwizard/playlist-action-job";
 import { Hono } from "hono";
 import type { PlaylistActionServices } from "../../../composition/playlist-actions";
@@ -26,9 +27,9 @@ export const jobsRoute = new Hono<{
     const { accountId, payload } = c.req.valid("json");
 
     const result = await createCreatePlaylistActionJob({
-      accountId,
+      accountId: toAccountId(accountId),
       payload,
-      userId: session.user.id,
+      userId: toUserId(session.user.id),
     });
 
     if (result.type === "account_not_found") {

--- a/apps/api/src/usecase/playlist-actions/create-playlist-action-job.test.ts
+++ b/apps/api/src/usecase/playlist-actions/create-playlist-action-job.test.ts
@@ -1,3 +1,9 @@
+import {
+  toAccountId,
+  toProviderAccountId,
+  toUserId,
+} from "@playlistwizard/core/ids";
+import { Provider } from "@playlistwizard/core/provider";
 import type { PlanStepsCreatePayload } from "@playlistwizard/playlist-action-job";
 import { describe, expect, it, vi } from "vitest";
 import { createCreatePlaylistActionJobUsecase } from "./create-playlist-action-job";
@@ -22,10 +28,10 @@ const createDeps = (overrides?: {
       overrides?.accountFound === false
         ? null
         : {
-            id: "account-id",
-            providerAccountId: "provider-account-id",
-            providerId: "google",
-            userId: "user-id",
+            id: toAccountId("account-id"),
+            providerAccountId: toProviderAccountId("provider-account-id"),
+            providerId: Provider.GOOGLE,
+            userId: toUserId("user-id"),
           },
     ),
   };
@@ -54,7 +60,11 @@ describe("createCreatePlaylistActionJobUsecase", () => {
     const usecase = createCreatePlaylistActionJobUsecase(deps);
 
     await expect(
-      usecase({ accountId: "account-id", payload, userId: "user-id" }),
+      usecase({
+        accountId: toAccountId("account-id"),
+        payload,
+        userId: toUserId("user-id"),
+      }),
     ).resolves.toEqual({ jobId: "job-id", type: "created" });
 
     expect(deps.jobs.createCreatePlaylistJob).toHaveBeenCalledWith({
@@ -74,7 +84,11 @@ describe("createCreatePlaylistActionJobUsecase", () => {
     const usecase = createCreatePlaylistActionJobUsecase(deps);
 
     await expect(
-      usecase({ accountId: "account-id", payload, userId: "user-id" }),
+      usecase({
+        accountId: toAccountId("account-id"),
+        payload,
+        userId: toUserId("user-id"),
+      }),
     ).resolves.toEqual({ type: "account_not_found" });
 
     expect(deps.jobs.createCreatePlaylistJob).not.toHaveBeenCalled();
@@ -86,7 +100,11 @@ describe("createCreatePlaylistActionJobUsecase", () => {
     const usecase = createCreatePlaylistActionJobUsecase(deps);
 
     await expect(
-      usecase({ accountId: "account-id", payload, userId: "user-id" }),
+      usecase({
+        accountId: toAccountId("account-id"),
+        payload,
+        userId: toUserId("user-id"),
+      }),
     ).resolves.toEqual({ type: "enqueue_failed" });
 
     expect(deps.jobs.markCreatePlaylistJobEnqueueFailed).toHaveBeenCalledWith({

--- a/apps/api/src/usecase/playlist-actions/create-playlist-action-job.ts
+++ b/apps/api/src/usecase/playlist-actions/create-playlist-action-job.ts
@@ -1,3 +1,4 @@
+import type { AccountId, UserId } from "@playlistwizard/core/ids";
 import type { PlanStepsCreatePayload } from "@playlistwizard/playlist-action-job";
 import { toJobId, toStepId } from "@playlistwizard/playlist-action-job";
 import { formatError } from "../../shared/format-error";
@@ -9,9 +10,9 @@ import type {
 } from "./ports";
 
 export type CreatePlaylistActionJobCommand = {
-  accountId: string;
+  accountId: AccountId;
   payload: PlanStepsCreatePayload;
-  userId: string;
+  userId: UserId;
 };
 
 export type CreatePlaylistActionJobResult =

--- a/apps/api/src/usecase/playlist-actions/ports.ts
+++ b/apps/api/src/usecase/playlist-actions/ports.ts
@@ -1,4 +1,13 @@
 import type {
+  AccountId,
+  PlaylistId,
+  ProviderAccountId,
+  UserId,
+  VideoId,
+} from "@playlistwizard/core/ids";
+import type { PlaylistPrivacy } from "@playlistwizard/core/playlist";
+import type { Provider } from "@playlistwizard/core/provider";
+import type {
   CreatePlaylistStepPayload,
   JobId,
   JobStatus,
@@ -14,16 +23,16 @@ export type IdGenerator = {
 };
 
 export type ExecutionAccount = {
-  id: string;
-  userId: string;
-  providerId: string;
-  providerAccountId: string;
+  id: AccountId;
+  userId: UserId;
+  providerId: Provider;
+  providerAccountId: ProviderAccountId;
 };
 
 export type AccountAccess = {
   findExecutionAccount(input: {
-    accountId: string;
-    userId: string;
+    accountId: AccountId;
+    userId: UserId;
   }): Promise<ExecutionAccount | null>;
 };
 
@@ -33,8 +42,8 @@ export type PlaylistActionJobRecord = {
   status: JobStatus;
   completeSteps: number;
   totalSteps: number;
-  userId: string;
-  accountId: string;
+  userId: UserId;
+  accountId: AccountId;
   error: unknown;
   createdAt: Date;
   updatedAt: Date;
@@ -56,17 +65,17 @@ export type PlaylistActionStepRecord = {
 export type AddPlaylistItemStepDraft = {
   id: StepId;
   jobId: JobId;
-  playlistId: string;
-  videoId: string;
+  playlistId: PlaylistId;
+  videoId: VideoId;
 };
 
 export type PlaylistActionJobRepository = {
   createCreatePlaylistJob(input: {
-    accountId: string;
+    accountId: AccountId;
     jobId: JobId;
     planStepId: StepId;
     planStepsPayload: PlanStepsCreatePayload;
-    userId: string;
+    userId: UserId;
   }): Promise<void>;
   markCreatePlaylistJobEnqueueFailed(input: {
     errorMessage: string;
@@ -117,7 +126,7 @@ export type StepQueue = {
 export type ProviderTokenProvider = {
   getAccessToken(input: {
     account: ExecutionAccount;
-    userId: string;
+    userId: UserId;
   }): Promise<string>;
 };
 
@@ -125,6 +134,6 @@ export type PlaylistProviderGateway = {
   createPlaylist(input: {
     accessToken: string;
     name: string;
-    privacy: string;
+    privacy: PlaylistPrivacy;
   }): Promise<{ id: string }>;
 };

--- a/apps/api/src/usecase/playlist-actions/process-playlist-action-step.test.ts
+++ b/apps/api/src/usecase/playlist-actions/process-playlist-action-step.test.ts
@@ -1,0 +1,253 @@
+import {
+  toAccountId,
+  toProviderAccountId,
+  toUserId,
+} from "@playlistwizard/core/ids";
+import { Provider } from "@playlistwizard/core/provider";
+import {
+  JobStatus,
+  JobType,
+  StepStatus,
+  StepType,
+  toJobId,
+  toStepId,
+} from "@playlistwizard/playlist-action-job";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AccountAccess,
+  IdGenerator,
+  PlaylistActionJobRecord,
+  PlaylistActionJobRepository,
+  PlaylistActionStepRecord,
+  PlaylistProviderGateway,
+  ProviderTokenProvider,
+  StepQueue,
+} from "./ports";
+import { createProcessPlaylistActionStepUsecase } from "./process-playlist-action-step";
+
+const now = new Date("2026-06-12T00:00:00.000Z");
+const accountId = toAccountId("account-id");
+const userId = toUserId("user-id");
+const jobId = toJobId("job-id");
+
+const createJobRecord = (
+  overrides: Partial<PlaylistActionJobRecord> = {},
+): PlaylistActionJobRecord => ({
+  accountId,
+  completeSteps: 0,
+  createdAt: now,
+  error: null,
+  id: jobId,
+  status: JobStatus.Running,
+  totalSteps: 0,
+  type: JobType.Create,
+  updatedAt: now,
+  userId,
+  ...overrides,
+});
+
+const createStepRecord = (
+  overrides: Partial<PlaylistActionStepRecord>,
+): PlaylistActionStepRecord => ({
+  attemptCount: 1,
+  createdAt: now,
+  failedAt: null,
+  id: toStepId("step-id"),
+  jobId,
+  lastError: null,
+  payload: {},
+  status: StepStatus.Running,
+  type: StepType.PlanSteps,
+  updatedAt: now,
+  ...overrides,
+});
+
+const createDeps = () => {
+  const accounts: AccountAccess = {
+    findExecutionAccount: vi.fn(async () => ({
+      id: accountId,
+      providerAccountId: toProviderAccountId("provider-account-id"),
+      providerId: Provider.GOOGLE,
+      userId,
+    })),
+  };
+  const idGenerator: IdGenerator = {
+    generate: vi.fn(),
+  };
+  const jobs: PlaylistActionJobRepository = {
+    claimStep: vi.fn(),
+    completeStep: vi.fn(async () => undefined),
+    createAddPlaylistItemStepsForCreatedPlaylist: vi.fn(async () => undefined),
+    createCreatePlaylistJob: vi.fn(async () => undefined),
+    createCreatePlaylistStepAndStartJob: vi.fn(async () => undefined),
+    failStep: vi.fn(async () => undefined),
+    findCreatePlaylistStep: vi.fn(async () => null),
+    findJob: vi.fn(async () => createJobRecord()),
+    findStep: vi.fn(async () => null),
+    isStepRunning: vi.fn(async () => false),
+    markCreatePlaylistJobEnqueueFailed: vi.fn(async () => undefined),
+    resetRunningStepToPendingWithError: vi.fn(async () => undefined),
+    updateRunningCreatePlaylistPayload: vi.fn(async () => undefined),
+  };
+  const playlistGateway: PlaylistProviderGateway = {
+    createPlaylist: vi.fn(async () => ({ id: "created-playlist-id" })),
+  };
+  const stepQueue: StepQueue = {
+    send: vi.fn(async () => undefined),
+  };
+  const tokenProvider: ProviderTokenProvider = {
+    getAccessToken: vi.fn(async () => "access-token"),
+  };
+
+  return {
+    accounts,
+    idGenerator,
+    jobs,
+    playlistGateway,
+    stepQueue,
+    tokenProvider,
+  };
+};
+
+describe("createProcessPlaylistActionStepUsecase", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("plans a CreatePlaylist step from a PlanSteps Create payload", async () => {
+    const deps = createDeps();
+    const planStepId = toStepId("plan-step-id");
+    const createPlaylistStepId = toStepId("create-playlist-step-id");
+
+    vi.mocked(deps.idGenerator.generate).mockReturnValueOnce(
+      createPlaylistStepId,
+    );
+    vi.mocked(deps.jobs.claimStep).mockResolvedValueOnce(
+      createStepRecord({
+        id: planStepId,
+        payload: {
+          newPlaylistName: "New playlist",
+          privacy: "private",
+        },
+        type: StepType.PlanSteps,
+      }),
+    );
+
+    const usecase = createProcessPlaylistActionStepUsecase(deps);
+
+    await usecase({ stepId: planStepId });
+
+    expect(deps.jobs.createCreatePlaylistStepAndStartJob).toHaveBeenCalledWith({
+      jobId,
+      payload: {
+        name: "New playlist",
+        privacy: "private",
+      },
+      stepId: createPlaylistStepId,
+    });
+    expect(deps.stepQueue.send).toHaveBeenCalledWith({
+      stepId: createPlaylistStepId,
+    });
+    expect(deps.jobs.completeStep).toHaveBeenCalledWith({
+      jobId,
+      stepId: planStepId,
+    });
+  });
+
+  it("plans AddPlaylistItem steps after the provider playlist is created", async () => {
+    const deps = createDeps();
+    const createPlaylistStepId = toStepId("create-playlist-step-id");
+    const firstAddStepId = toStepId("add-step-1");
+    const secondAddStepId = toStepId("add-step-2");
+
+    vi.mocked(deps.idGenerator.generate)
+      .mockReturnValueOnce(firstAddStepId)
+      .mockReturnValueOnce(secondAddStepId);
+    vi.mocked(deps.jobs.claimStep).mockResolvedValueOnce(
+      createStepRecord({
+        id: createPlaylistStepId,
+        payload: {
+          afterCreate: {
+            enqueue: [
+              {
+                payload: { videoId: "video-1" },
+                type: StepType.AddPlaylistItem,
+              },
+              {
+                payload: { videoId: "video-2" },
+                type: StepType.AddPlaylistItem,
+              },
+            ],
+          },
+          name: "New playlist",
+          privacy: "unlisted",
+        },
+        type: StepType.CreatePlaylist,
+      }),
+    );
+
+    const usecase = createProcessPlaylistActionStepUsecase(deps);
+
+    await usecase({ stepId: createPlaylistStepId });
+
+    expect(deps.playlistGateway.createPlaylist).toHaveBeenCalledWith({
+      accessToken: "access-token",
+      name: "New playlist",
+      privacy: "unlisted",
+    });
+    expect(deps.jobs.updateRunningCreatePlaylistPayload).toHaveBeenCalledWith({
+      payload: expect.objectContaining({
+        createdPlaylistId: "created-playlist-id",
+      }),
+      stepId: createPlaylistStepId,
+    });
+    expect(
+      deps.jobs.createAddPlaylistItemStepsForCreatedPlaylist,
+    ).toHaveBeenCalledWith({
+      jobId,
+      parentPayload: {
+        afterCreate: {
+          enqueue: [
+            {
+              payload: { videoId: "video-1" },
+              type: StepType.AddPlaylistItem,
+            },
+            {
+              payload: { videoId: "video-2" },
+              type: StepType.AddPlaylistItem,
+            },
+          ],
+        },
+        createdPlaylistId: "created-playlist-id",
+        name: "New playlist",
+        plannedAddPlaylistItemStepIds: [firstAddStepId, secondAddStepId],
+        privacy: "unlisted",
+      },
+      parentStepId: createPlaylistStepId,
+      steps: [
+        {
+          id: firstAddStepId,
+          jobId,
+          playlistId: "created-playlist-id",
+          videoId: "video-1",
+        },
+        {
+          id: secondAddStepId,
+          jobId,
+          playlistId: "created-playlist-id",
+          videoId: "video-2",
+        },
+      ],
+    });
+    expect(deps.stepQueue.send).toHaveBeenNthCalledWith(1, {
+      stepId: firstAddStepId,
+    });
+    expect(deps.stepQueue.send).toHaveBeenNthCalledWith(2, {
+      stepId: secondAddStepId,
+    });
+    expect(deps.jobs.completeStep).toHaveBeenCalledWith({
+      jobId,
+      stepId: createPlaylistStepId,
+    });
+  });
+});

--- a/apps/api/src/usecase/playlist-actions/process-playlist-action-step.ts
+++ b/apps/api/src/usecase/playlist-actions/process-playlist-action-step.ts
@@ -1,3 +1,8 @@
+import { toPlaylistId, toVideoId } from "@playlistwizard/core/ids";
+import {
+  planAddPlaylistItemsAfterCreate,
+  planCreatePlaylistOperation,
+} from "@playlistwizard/core/playlist-actions";
 import type {
   CreatePlaylistStepPayload,
   StepQueueMessage,
@@ -67,10 +72,10 @@ const executePlanStepsCreate = async (
 
   if (!job) throw new Error(`Job not found: ${step.jobId}`);
 
-  const createPayload: CreatePlaylistStepPayload = {
+  const createPayload: CreatePlaylistStepPayload = planCreatePlaylistOperation({
     name: payload.newPlaylistName,
     privacy: payload.privacy,
-  };
+  });
 
   const existingCreateStep = await deps.jobs.findCreatePlaylistStep(step.jobId);
   const createPlaylistStepId =
@@ -137,11 +142,18 @@ const executeCreatePlaylist = async (
     payload.plannedAddPlaylistItemStepIds?.map(toStepId);
 
   if (!addPlaylistItemStepIds) {
-    const addSteps = payload.afterCreate.enqueue.map((item) => ({
+    const addPlaylistItemOperations = planAddPlaylistItemsAfterCreate({
+      createdPlaylistId: toPlaylistId(createdPlaylistId),
+      items: payload.afterCreate.enqueue.map((item) => ({
+        videoId: toVideoId(item.payload.videoId),
+      })),
+    });
+
+    const addSteps = addPlaylistItemOperations.map((operation) => ({
       id: toStepId(deps.idGenerator.generate()),
       jobId: step.jobId,
-      playlistId: createdPlaylistId,
-      videoId: item.payload.videoId,
+      playlistId: operation.playlistId,
+      videoId: operation.videoId,
     }));
 
     addPlaylistItemStepIds = addSteps.map((addStep) => addStep.id);

--- a/apps/www/src/entities/ids.ts
+++ b/apps/www/src/entities/ids.ts
@@ -1,27 +1,16 @@
-declare const _userId: unique symbol;
-export type UserId = string & { readonly [_userId]: never };
-export const toUserId = (id: string): UserId => id as UserId;
-
-declare const _accountId: unique symbol;
-export type AccountId = string & { readonly [_accountId]: never };
-export const toAccountId = (id: string): AccountId => id as AccountId;
-
-declare const _providerAccountId: unique symbol;
-export type ProviderAccountId = string & {
-  readonly [_providerAccountId]: never;
-};
-export const toProviderAccountId = (id: string): ProviderAccountId =>
-  id as ProviderAccountId;
-
-declare const _playlistId: unique symbol;
-export type PlaylistId = string & { readonly [_playlistId]: never };
-export const toPlaylistId = (id: string): PlaylistId => id as PlaylistId;
-
-declare const _playlistItemId: unique symbol;
-export type PlaylistItemId = string & { readonly [_playlistItemId]: never };
-export const toPlaylistItemId = (id: string): PlaylistItemId =>
-  id as PlaylistItemId;
-
-declare const _videoId: unique symbol;
-export type VideoId = string & { readonly [_videoId]: never };
-export const toVideoId = (id: string): VideoId => id as VideoId;
+export type {
+  AccountId,
+  PlaylistId,
+  PlaylistItemId,
+  ProviderAccountId,
+  UserId,
+  VideoId,
+} from "@playlistwizard/core/ids";
+export {
+  toAccountId,
+  toPlaylistId,
+  toPlaylistItemId,
+  toProviderAccountId,
+  toUserId,
+  toVideoId,
+} from "@playlistwizard/core/ids";

--- a/apps/www/src/entities/provider.ts
+++ b/apps/www/src/entities/provider.ts
@@ -1,3 +1,9 @@
-export enum Provider {
-  GOOGLE = "google",
-}
+import type { Provider as CoreProviderType } from "@playlistwizard/core/provider";
+import {
+  Provider as CoreProvider,
+  toProvider,
+} from "@playlistwizard/core/provider";
+
+export const Provider = CoreProvider;
+export { toProvider };
+export type Provider = CoreProviderType;

--- a/apps/www/src/entities/thumbnail.ts
+++ b/apps/www/src/entities/thumbnail.ts
@@ -1,5 +1,1 @@
-export type Thumbnail = {
-  url: string;
-  width: number;
-  height: number;
-};
+export type { Thumbnail } from "@playlistwizard/core/thumbnail";

--- a/apps/www/src/features/playlist/entities/playlist-item.ts
+++ b/apps/www/src/features/playlist/entities/playlist-item.ts
@@ -1,20 +1,7 @@
-import {
-  type PlaylistItemId,
-  toPlaylistItemId,
-  toVideoId,
-  type VideoId,
-} from "@/entities/ids";
-import type { Thumbnail } from "@/entities/thumbnail";
+import { toPlaylistItemId, toVideoId } from "@playlistwizard/core/ids";
+import type { PlaylistItem } from "@playlistwizard/core/playlist";
 
-export type PlaylistItem = {
-  id: PlaylistItemId;
-  title: string;
-  thumbnails: Thumbnail[];
-  position: number;
-  author: string;
-  videoId: VideoId;
-  url: string;
-};
+export type { PlaylistItem } from "@playlistwizard/core/playlist";
 
 type CreateDummyPlaylistItemInput = Partial<
   Omit<PlaylistItem, "id" | "videoId">
@@ -27,14 +14,14 @@ export function createDummyPlaylistItem(
   data: CreateDummyPlaylistItemInput,
 ): PlaylistItem {
   return {
-    id: toPlaylistItemId(data.id ?? "dummy-id"),
-    title: data.title ?? "Dummy Title",
-    thumbnails: data.thumbnails ?? [
-      { url: "https://example.com/thumbnail.jpg", width: 640, height: 480 },
-    ],
-    position: data.position ?? 0,
     author: data.author ?? "Dummy Author",
-    videoId: toVideoId(data.videoId ?? "dummy-video-id"),
+    id: toPlaylistItemId(data.id ?? "dummy-id"),
+    position: data.position ?? 0,
+    thumbnails: data.thumbnails ?? [
+      { height: 480, url: "https://example.com/thumbnail.jpg", width: 640 },
+    ],
+    title: data.title ?? "Dummy Title",
     url: data.url ?? "https://example.com/video",
+    videoId: toVideoId(data.videoId ?? "dummy-video-id"),
   };
 }

--- a/apps/www/src/features/playlist/entities/playlist.ts
+++ b/apps/www/src/features/playlist/entities/playlist.ts
@@ -1,32 +1,9 @@
-import {
-  type AccountId,
-  type PlaylistId,
-  toAccountId,
-  toPlaylistId,
-} from "@/entities/ids";
-import { Provider } from "@/entities/provider";
-import type { Thumbnail } from "@/entities/thumbnail";
-import type { PlaylistItem } from "./playlist-item";
+import { toAccountId, toPlaylistId } from "@playlistwizard/core/ids";
+import type { Playlist } from "@playlistwizard/core/playlist";
+import { Provider } from "@playlistwizard/core/provider";
 
-export type Playlist = {
-  id: PlaylistId;
-  accountId: AccountId;
-  title: string;
-  thumbnails: Thumbnail[];
-  itemsTotal: number;
-  url: string;
-  provider: Provider;
-};
-
-export type FullPlaylist = Playlist & {
-  items: PlaylistItem[];
-};
-
-export enum PlaylistPrivacy {
-  Public = "public",
-  Private = "private",
-  Unlisted = "unlisted",
-}
+export type { FullPlaylist, Playlist } from "@playlistwizard/core/playlist";
+export { PlaylistPrivacy } from "@playlistwizard/core/playlist";
 
 type CreateDummyPlaylistInput = Partial<Omit<Playlist, "id" | "accountId">> & {
   id?: string;
@@ -35,14 +12,14 @@ type CreateDummyPlaylistInput = Partial<Omit<Playlist, "id" | "accountId">> & {
 
 export function createDummyPlaylist(data: CreateDummyPlaylistInput): Playlist {
   return {
-    id: toPlaylistId(data.id ?? "dummy-id"),
     accountId: toAccountId(data.accountId ?? "dummy-account-id"),
-    title: data.title ?? "Dummy Title",
-    thumbnails: data.thumbnails ?? [
-      { url: "https://example.com/thumbnail.jpg", width: 640, height: 480 },
-    ],
+    id: toPlaylistId(data.id ?? "dummy-id"),
     itemsTotal: data.itemsTotal ?? 0,
-    url: data.url ?? "https://example.com/playlist",
     provider: data.provider ?? Provider.GOOGLE,
+    thumbnails: data.thumbnails ?? [
+      { height: 480, url: "https://example.com/thumbnail.jpg", width: 640 },
+    ],
+    title: data.title ?? "Dummy Title",
+    url: data.url ?? "https://example.com/playlist",
   };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,26 @@
     "./structured-playlists": {
       "import": "./dist/structured-playlists/index.js",
       "types": "./dist/structured-playlists/index.d.ts"
+    },
+    "./ids": {
+      "import": "./dist/ids.js",
+      "types": "./dist/ids.d.ts"
+    },
+    "./playlist": {
+      "import": "./dist/playlist/index.js",
+      "types": "./dist/playlist/index.d.ts"
+    },
+    "./playlist-actions": {
+      "import": "./dist/playlist-actions/index.js",
+      "types": "./dist/playlist-actions/index.d.ts"
+    },
+    "./provider": {
+      "import": "./dist/provider.js",
+      "types": "./dist/provider.d.ts"
+    },
+    "./thumbnail": {
+      "import": "./dist/thumbnail.js",
+      "types": "./dist/thumbnail.d.ts"
     }
   },
   "files": [

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -1,0 +1,27 @@
+declare const _userId: unique symbol;
+export type UserId = string & { readonly [_userId]: never };
+export const toUserId = (id: string): UserId => id as UserId;
+
+declare const _accountId: unique symbol;
+export type AccountId = string & { readonly [_accountId]: never };
+export const toAccountId = (id: string): AccountId => id as AccountId;
+
+declare const _providerAccountId: unique symbol;
+export type ProviderAccountId = string & {
+  readonly [_providerAccountId]: never;
+};
+export const toProviderAccountId = (id: string): ProviderAccountId =>
+  id as ProviderAccountId;
+
+declare const _playlistId: unique symbol;
+export type PlaylistId = string & { readonly [_playlistId]: never };
+export const toPlaylistId = (id: string): PlaylistId => id as PlaylistId;
+
+declare const _playlistItemId: unique symbol;
+export type PlaylistItemId = string & { readonly [_playlistItemId]: never };
+export const toPlaylistItemId = (id: string): PlaylistItemId =>
+  id as PlaylistItemId;
+
+declare const _videoId: unique symbol;
+export type VideoId = string & { readonly [_videoId]: never };
+export const toVideoId = (id: string): VideoId => id as VideoId;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./ids";
+export * from "./playlist";
+export * from "./playlist-actions";
+export * from "./provider";
+export * from "./thumbnail";

--- a/packages/core/src/playlist-actions/create-playlist.test.ts
+++ b/packages/core/src/playlist-actions/create-playlist.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { toPlaylistId, toVideoId } from "../ids";
+import { PlaylistPrivacy } from "../playlist";
+import {
+  planAddPlaylistItemsAfterCreate,
+  planCreatePlaylistOperation,
+} from "./create-playlist";
+
+describe("planCreatePlaylistOperation", () => {
+  it("plans the Provider playlist creation operation from user-visible input", () => {
+    expect(
+      planCreatePlaylistOperation({
+        name: "New playlist",
+        privacy: PlaylistPrivacy.Private,
+      }),
+    ).toEqual({
+      name: "New playlist",
+      privacy: "private",
+    });
+  });
+});
+
+describe("planAddPlaylistItemsAfterCreate", () => {
+  it("plans item additions against the created Playlist", () => {
+    const playlistId = toPlaylistId("playlist-id");
+    const firstVideoId = toVideoId("first-video-id");
+    const secondVideoId = toVideoId("second-video-id");
+
+    expect(
+      planAddPlaylistItemsAfterCreate({
+        createdPlaylistId: playlistId,
+        items: [{ videoId: firstVideoId }, { videoId: secondVideoId }],
+      }),
+    ).toEqual([
+      { playlistId, videoId: firstVideoId },
+      { playlistId, videoId: secondVideoId },
+    ]);
+  });
+
+  it("keeps an empty follow-up plan empty", () => {
+    expect(
+      planAddPlaylistItemsAfterCreate({
+        createdPlaylistId: toPlaylistId("playlist-id"),
+        items: [],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/playlist-actions/create-playlist.ts
+++ b/packages/core/src/playlist-actions/create-playlist.ts
@@ -1,0 +1,37 @@
+import type { PlaylistId, VideoId } from "../ids";
+import type { PlaylistPrivacy } from "../playlist";
+
+export type CreatePlaylistActionInput = {
+  name: string;
+  privacy: PlaylistPrivacy;
+};
+
+export type CreatePlaylistOperation = {
+  name: string;
+  privacy: PlaylistPrivacy;
+};
+
+export const planCreatePlaylistOperation = (
+  input: CreatePlaylistActionInput,
+): CreatePlaylistOperation => ({
+  name: input.name,
+  privacy: input.privacy,
+});
+
+export type AddPlaylistItemAfterCreateInput = {
+  videoId: VideoId;
+};
+
+export type AddPlaylistItemAfterCreateOperation = {
+  playlistId: PlaylistId;
+  videoId: VideoId;
+};
+
+export const planAddPlaylistItemsAfterCreate = (input: {
+  createdPlaylistId: PlaylistId;
+  items: AddPlaylistItemAfterCreateInput[];
+}): AddPlaylistItemAfterCreateOperation[] =>
+  input.items.map((item) => ({
+    playlistId: input.createdPlaylistId,
+    videoId: item.videoId,
+  }));

--- a/packages/core/src/playlist-actions/index.ts
+++ b/packages/core/src/playlist-actions/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-playlist";

--- a/packages/core/src/playlist/index.ts
+++ b/packages/core/src/playlist/index.ts
@@ -1,0 +1,36 @@
+import type { AccountId, PlaylistId, PlaylistItemId, VideoId } from "../ids";
+import type { Provider } from "../provider";
+import type { Thumbnail } from "../thumbnail";
+
+export const PlaylistPrivacy = {
+  Public: "public",
+  Private: "private",
+  Unlisted: "unlisted",
+} as const;
+
+export type PlaylistPrivacy =
+  (typeof PlaylistPrivacy)[keyof typeof PlaylistPrivacy];
+
+export type Playlist = {
+  id: PlaylistId;
+  accountId: AccountId;
+  title: string;
+  thumbnails: Thumbnail[];
+  itemsTotal: number;
+  url: string;
+  provider: Provider;
+};
+
+export type PlaylistItem = {
+  id: PlaylistItemId;
+  title: string;
+  thumbnails: Thumbnail[];
+  position: number;
+  author: string;
+  videoId: VideoId;
+  url: string;
+};
+
+export type FullPlaylist = Playlist & {
+  items: PlaylistItem[];
+};

--- a/packages/core/src/provider.test.ts
+++ b/packages/core/src/provider.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { Provider, toProvider } from "./provider";
+
+describe("toProvider", () => {
+  it("accepts a supported Provider value", () => {
+    expect(toProvider("google")).toBe(Provider.GOOGLE);
+  });
+
+  it("rejects an unsupported Provider value", () => {
+    expect(() => toProvider("spotify")).toThrow(
+      "Unsupported provider: spotify",
+    );
+  });
+});

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -1,0 +1,10 @@
+export const Provider = {
+  GOOGLE: "google",
+} as const;
+
+export type Provider = (typeof Provider)[keyof typeof Provider];
+
+export const toProvider = (provider: string): Provider => {
+  if (provider === Provider.GOOGLE) return provider;
+  throw new Error(`Unsupported provider: ${provider}`);
+};

--- a/packages/core/src/thumbnail.ts
+++ b/packages/core/src/thumbnail.ts
@@ -1,0 +1,5 @@
+export type Thumbnail = {
+  url: string;
+  width: number;
+  height: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@hono/valibot-validator':
         specifier: ^0.6.1
         version: 0.6.1(hono@4.12.21)(valibot@1.2.0(typescript@5.9.3))
+      '@playlistwizard/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@playlistwizard/db':
         specifier: workspace:*
         version: link:../../packages/db


### PR DESCRIPTION
## Summary
- Add playlist-oriented domain primitives to `@playlistwizard/core`, including branded IDs, Provider, Thumbnail, Playlist models, and create-playlist action planning helpers.
- Wire the API playlist action usecases to depend on core domain types while keeping infrastructure as adapters from DB/provider values.
- Keep the frontend scope narrow by re-exporting existing entity wrappers from core without broadly unifying frontend and API implementations.
- Add core unit tests and API usecase tests covering the extracted playlist action planning flow.

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm --filter @playlistwizard/core build && pnpm --filter @playlistwizard/core test`
- `pnpm --filter @playlistwizard/api build && pnpm --filter @playlistwizard/api test`
- `pnpm --filter @playlistwizard/www test`
- `pnpm --filter @playlistwizard/www build`

## Notes
- `pnpm lint` exits successfully but still reports existing warnings from Biome schema version, `.wrangler/tmp`, and existing Next/env patterns.
- `docs/reviews/` is intentionally left untracked and excluded from this PR.
