### PR TITLE
feat(api): establish versioned public contract

### DIFF
--- a/.changeset/tidy-api-paths.md
+++ b/.changeset/tidy-api-paths.md
@@ -1,0 +1,5 @@
+---
+"@playlistwizard/shared": patch
+---
+
+Expose the versioned PlaylistWizard API path contract and URL resolver.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "@playlistwizard/core": "workspace:*",
     "@playlistwizard/db": "workspace:*",
     "@playlistwizard/playlist-action-job": "workspace:*",
+    "@playlistwizard/shared": "workspace:*",
     "@sentry/cloudflare": "10.54.0",
     "better-auth": "1.6.19",
     "drizzle-orm": "0.45.2",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,3 +1,4 @@
+import { API_V1_BASE_PATH } from "@playlistwizard/shared";
 import * as Sentry from "@sentry/cloudflare";
 import { Hono } from "hono";
 import {
@@ -25,7 +26,9 @@ type Variables = {
   session: AuthSession;
 };
 
-export const app = new Hono<{ Bindings: Env; Variables: Variables }>()
+// Keep the versioned application separate so Hono RPC clients can target the
+// v1 contract without exposing the unversioned Worker root as a public API.
+const v1App = new Hono<{ Bindings: Env; Variables: Variables }>()
   .use("*", createCorsMiddleware())
   .use("/jobs/*", requireTrustedOriginForMutation)
   .use(async (c, next) => {
@@ -60,4 +63,6 @@ export const app = new Hono<{ Bindings: Env; Variables: Variables }>()
     return c.text("Internal Server Error", 500);
   });
 
-export type AppType = typeof app;
+export const app = new Hono<{ Bindings: Env }>().route(API_V1_BASE_PATH, v1App);
+
+export type AppType = typeof v1App;

--- a/apps/api/src/exported-types.ts
+++ b/apps/api/src/exported-types.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 
-// Type-only public surface for @playlistwizard/api.
+// Type-only public surface for the v1 @playlistwizard/api contract.
 // Keep this independent from Worker implementation modules so package builds that
 // only need the RPC client do not pull in Cloudflare or DB-specific dependencies.
 const appType = new Hono()

--- a/apps/api/src/infrastructure/auth/better-auth.ts
+++ b/apps/api/src/infrastructure/auth/better-auth.ts
@@ -1,4 +1,5 @@
 import * as schema from "@playlistwizard/db";
+import { API_AUTH_BASE_PATH } from "@playlistwizard/shared";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import type { Env } from "../../env";
@@ -26,6 +27,8 @@ export const createAuth = (
 ) => {
   return betterAuth({
     baseURL: env.API_URL,
+    // Authentication is part of the public API contract and must move with v1.
+    basePath: API_AUTH_BASE_PATH,
     secret: env.BETTER_AUTH_SECRET,
     database: drizzleAdapter(db, { provider: "pg", schema }),
     trustedOrigins: getTrustedOrigins(env),

--- a/apps/www/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/www/src/app/api/auth/[...all]/route.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { toVersionedAuthPath } from "./route";
+
+describe("toVersionedAuthPath", () => {
+  it("moves Better Auth routes under the v1 API prefix", () => {
+    expect(toVersionedAuthPath("/api/auth/sign-in/social")).toBe(
+      "/v1/api/auth/sign-in/social",
+    );
+  });
+});

--- a/apps/www/src/app/api/auth/[...all]/route.ts
+++ b/apps/www/src/app/api/auth/[...all]/route.ts
@@ -1,15 +1,14 @@
+import { API_AUTH_BASE_PATH, resolveApiUrl } from "@playlistwizard/shared";
 import { type NextRequest, NextResponse } from "next/server";
+import { requirePublicApiOrigin } from "@/lib/api-url";
 
-const getAuthBaseUrl = (): string => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-  if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not set");
-  return baseUrl;
-};
+export const toVersionedAuthPath = (pathname: string): string =>
+  pathname.replace(/^\/api\/auth(?=\/|$)/, API_AUTH_BASE_PATH);
 
 const redirectToWorkersAuth = (request: NextRequest): NextResponse => {
-  const url = new URL(
-    request.nextUrl.pathname + request.nextUrl.search,
-    getAuthBaseUrl(),
+  const url = resolveApiUrl(
+    requirePublicApiOrigin(),
+    toVersionedAuthPath(request.nextUrl.pathname) + request.nextUrl.search,
   );
   return NextResponse.redirect(url, 307);
 };

--- a/apps/www/src/features/playlist/job-progress-provider.test.ts
+++ b/apps/www/src/features/playlist/job-progress-provider.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { createJobProgressWebSocketUrl } from "./job-progress-provider";
+
+describe("createJobProgressWebSocketUrl", () => {
+  it("targets the v1 progress endpoint", () => {
+    expect(createJobProgressWebSocketUrl("https://api.example.com")).toBe(
+      "wss://api.example.com/v1/jobs/progress",
+    );
+  });
+});

--- a/apps/www/src/features/playlist/job-progress-provider.tsx
+++ b/apps/www/src/features/playlist/job-progress-provider.tsx
@@ -5,6 +5,7 @@ import {
   JobProgressEventType,
   parseSerializedJobProgressEvent,
 } from "@playlistwizard/playlist-action-job";
+import { API_JOB_PROGRESS_PATH } from "@playlistwizard/shared";
 import {
   createContext,
   type PropsWithChildren,
@@ -14,6 +15,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { requirePublicApiOrigin } from "@/lib/api-url";
 import { FeatureFlagName } from "@/lib/feature-flags";
 import { useFeatureFlag } from "@/presentation/hooks/useFeatureFlag";
 
@@ -29,14 +31,8 @@ type JobProgressContextValue = {
 
 const JobProgressContext = createContext<JobProgressContextValue | null>(null);
 
-const getApiUrl = (): string => {
-  const url = process.env.NEXT_PUBLIC_API_URL;
-  if (!url) throw new Error("NEXT_PUBLIC_API_URL is not set");
-  return url;
-};
-
 export const createJobProgressWebSocketUrl = (apiUrl: string): string => {
-  const url = new URL("/jobs/progress", apiUrl);
+  const url = new URL(API_JOB_PROGRESS_PATH, apiUrl);
   if (url.protocol === "https:") {
     url.protocol = "wss:";
   } else if (url.protocol === "http:") {
@@ -98,7 +94,9 @@ export function JobProgressProvider({ children }: PropsWithChildren) {
       setIsReady(false);
 
       let receivedSnapshot = false;
-      socket = new WebSocket(createJobProgressWebSocketUrl(getApiUrl()));
+      socket = new WebSocket(
+        createJobProgressWebSocketUrl(requirePublicApiOrigin()),
+      );
 
       snapshotTimer = setTimeout(() => {
         socket?.close(1000, "Snapshot timeout");

--- a/apps/www/src/lib/api-url.test.ts
+++ b/apps/www/src/lib/api-url.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getPublicApiOrigin,
+  getServerApiOrigin,
+  requirePublicApiOrigin,
+} from "./api-url";
+
+const originalPublicApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalServerApiUrl = process.env.API_URL;
+
+afterEach(() => {
+  process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+  process.env.API_URL = originalServerApiUrl;
+});
+
+describe("API origin configuration", () => {
+  it("returns the configured public API origin", () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.example.com";
+
+    expect(requirePublicApiOrigin()).toBe("https://api.example.com");
+  });
+
+  it("rejects a missing public API origin before making a request", () => {
+    delete process.env.NEXT_PUBLIC_API_URL;
+
+    expect(() => requirePublicApiOrigin()).toThrow(
+      "NEXT_PUBLIC_API_URL is not set",
+    );
+  });
+
+  it("allows Better Auth to resolve a missing public API origin", () => {
+    delete process.env.NEXT_PUBLIC_API_URL;
+
+    expect(getPublicApiOrigin()).toBeUndefined();
+  });
+
+  it("allows Better Auth to resolve a missing server API origin", () => {
+    delete process.env.API_URL;
+
+    expect(getServerApiOrigin()).toBeUndefined();
+  });
+});

--- a/apps/www/src/lib/api-url.ts
+++ b/apps/www/src/lib/api-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns the configured browser-visible API origin when available.
+ * Better Auth can resolve an omitted base URL from the current request.
+ */
+export const getPublicApiOrigin = (): string | undefined =>
+  process.env.NEXT_PUBLIC_API_URL;
+
+/**
+ * Returns the browser-visible API origin for direct HTTP and WebSocket clients.
+ * The environment contract intentionally excludes versioned paths.
+ */
+export const requirePublicApiOrigin = (): string => {
+  const origin = process.env.NEXT_PUBLIC_API_URL;
+  if (!origin) throw new Error("NEXT_PUBLIC_API_URL is not set");
+  return origin;
+};
+
+/**
+ * Returns the server-side API origin used to generate authentication URLs.
+ * Better Auth accepts an undefined base URL and resolves it from the request,
+ * which keeps modules importable in tests and build-time tooling.
+ */
+export const getServerApiOrigin = (): string | undefined => process.env.API_URL;

--- a/apps/www/src/lib/auth-client.ts
+++ b/apps/www/src/lib/auth-client.ts
@@ -1,7 +1,11 @@
+import { API_AUTH_BASE_PATH } from "@playlistwizard/shared";
 import { createAuthClient } from "better-auth/react";
+import { getPublicApiOrigin } from "./api-url";
 
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: getPublicApiOrigin(),
+  // Better Auth endpoints are versioned with the rest of the public API.
+  basePath: API_AUTH_BASE_PATH,
 });
 
 export const {

--- a/apps/www/src/lib/auth.ts
+++ b/apps/www/src/lib/auth.ts
@@ -1,12 +1,16 @@
+import { API_AUTH_BASE_PATH } from "@playlistwizard/shared";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
+import { getServerApiOrigin } from "./api-url";
 import { getAuthCookiePrefix } from "./auth-cookie";
 import { db } from "./db";
 import * as schema from "./db/schema";
 
 export const auth = betterAuth({
-  baseURL: process.env.API_URL,
+  baseURL: getServerApiOrigin(),
+  // Keep generated OAuth callback URLs aligned with the API Worker route.
+  basePath: API_AUTH_BASE_PATH,
   secret: process.env.BETTER_AUTH_SECRET,
   database: drizzleAdapter(db, { provider: "pg", schema }),
   socialProviders: {

--- a/apps/www/src/usecase/actions/dismiss-backend-jobs.ts
+++ b/apps/www/src/usecase/actions/dismiss-backend-jobs.ts
@@ -1,12 +1,7 @@
 import { dismissJobsResponseSchema } from "@playlistwizard/playlist-action-job";
 import { createApiClient } from "@playlistwizard/playlist-action-job-client";
 import * as v from "valibot";
-
-const getApiUrl = (): string => {
-  const url = process.env.NEXT_PUBLIC_API_URL;
-  if (!url) throw new Error("NEXT_PUBLIC_API_URL is not set");
-  return url;
-};
+import { requirePublicApiOrigin } from "@/lib/api-url";
 
 export type DismissBackendJobsResult =
   | { success: true; jobIds: string[] }
@@ -17,7 +12,7 @@ export async function dismissBackendJobs(
 ): Promise<DismissBackendJobsResult> {
   if (jobIds.length === 0) return { success: true, jobIds: [] };
 
-  const client = createApiClient(getApiUrl());
+  const client = createApiClient(requirePublicApiOrigin());
   const response = await client.jobs.dismiss.$post(
     {
       json: { jobIds },

--- a/apps/www/src/usecase/actions/enqueue-job.ts
+++ b/apps/www/src/usecase/actions/enqueue-job.ts
@@ -3,12 +3,7 @@ import { createJobResponseSchema } from "@playlistwizard/playlist-action-job";
 import { createApiClient } from "@playlistwizard/playlist-action-job-client";
 import * as v from "valibot";
 import type { AccountId } from "@/entities/ids";
-
-const getApiUrl = (): string => {
-  const url = process.env.NEXT_PUBLIC_API_URL;
-  if (!url) throw new Error("NEXT_PUBLIC_API_URL is not set");
-  return url;
-};
+import { requirePublicApiOrigin } from "@/lib/api-url";
 
 const formatError = (error: unknown): string => {
   if (error instanceof Error) return error.message;
@@ -41,7 +36,7 @@ export const enqueueCreateJob = async ({
   privacy: PlaylistPrivacy;
 }): Promise<EnqueueJobResult> => {
   try {
-    const client = createApiClient(getApiUrl());
+    const client = createApiClient(requirePublicApiOrigin());
     const response = await client.jobs.create.$post(
       {
         json: {

--- a/docs/adr/0007-use-durable-objects-for-live-job-progress-delivery.md
+++ b/docs/adr/0007-use-durable-objects-for-live-job-progress-delivery.md
@@ -54,7 +54,7 @@ Safe BackendJob construction belongs in `@playlistwizard/playlist-action-job` as
 
 Job progress WebSocket event schemas also belong in `@playlistwizard/playlist-action-job` so the API Worker, Durable Object, and Next.js client parse the same execution contract. Events include `snapshot`, `job.updated`, `job.removed`, and sanitized `error` messages. Error events should use fixed client-facing codes rather than free-form backend messages. Event schemas, BackendJob factories, event builder helpers, and `serialize`/`parse` helpers should be shared from this package rather than duplicated in API, Durable Object, or Next.js code.
 
-Changing the API URL environment contract is out of scope for the initial WebSocket migration. Next.js continues to use `NEXT_PUBLIC_API_URL` as the API origin for HTTP clients, and a small helper derives the WebSocket URL by resolving `/jobs/progress` against that origin and converting `http`/`https` to `ws`/`wss`.
+Changing the API URL environment contract is out of scope for the initial WebSocket migration. Next.js continues to use `NEXT_PUBLIC_API_URL` as the API origin for HTTP clients, and a small helper derives the WebSocket URL by resolving `/v1/jobs/progress` against that origin and converting `http`/`https` to `ws`/`wss`.
 
 Durable Objects hold only the currently connected WebSocket instances for a progress stream. They do not store Job progress, replay buffers, or durable state in DO storage. Progress state remains in the database and is restored through snapshots.
 
@@ -62,9 +62,9 @@ Name the Durable Object class `PlaylistActionJobProgressStream` and the binding 
 
 Register the Durable Object class with a migration tag such as `v1-playlist-action-job-progress-stream`.
 
-The API Worker, not the Durable Object, owns authentication and snapshot construction. On `/jobs/progress`, the API Worker checks Origin and session, reads a sanitized BackendJob snapshot for `session.user.id`, resolves the progress stream Durable Object, and hands the WebSocket plus serialized snapshot to that object. The Durable Object accepts the socket, sends the snapshot, stores the socket instance, and later broadcasts internal publish events.
+The API Worker, not the Durable Object, owns authentication and snapshot construction. On `/v1/jobs/progress`, the API Worker checks Origin and session, reads a sanitized BackendJob snapshot for `session.user.id`, resolves the progress stream Durable Object, and hands the WebSocket plus serialized snapshot to that object. The Durable Object accepts the socket, sends the snapshot, stores the socket instance, and later broadcasts internal publish events.
 
-The Durable Object exposes separate internal handlers for connection and publish concerns. The API Worker routes authenticated client upgrades to the object's `/connect` handler with the initial snapshot, while internal publishers call the object's `/publish` handler with validated progress events. The only externally reachable WebSocket route is the API Worker's `/jobs/progress` endpoint.
+The Durable Object exposes separate internal handlers for connection and publish concerns. The API Worker routes authenticated client upgrades to the object's `/connect` handler with the initial snapshot, while internal publishers call the object's `/publish` handler with validated progress events. The only externally reachable WebSocket route is the API Worker's `/v1/jobs/progress` endpoint.
 
 The initial snapshot is serialized by the API Worker using the shared event serializer before it is passed to the Durable Object. The Durable Object does not recalculate, reshape, or stringify the snapshot; it sends the serialized snapshot as the first client message after accepting the socket.
 

--- a/packages/playlist-action-job-client/package.json
+++ b/packages/playlist-action-job-client/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@playlistwizard/playlist-action-job": "workspace:*",
     "@playlistwizard/api": "workspace:*",
+    "@playlistwizard/shared": "workspace:*",
     "hono": "4.12.26"
   },
   "devDependencies": {

--- a/packages/playlist-action-job-client/src/client.ts
+++ b/packages/playlist-action-job-client/src/client.ts
@@ -1,6 +1,12 @@
 import type { AppType } from "@playlistwizard/api";
+import { API_V1_BASE_PATH, resolveApiUrl } from "@playlistwizard/shared";
 import { hc } from "hono/client";
 
-export const createApiClient = (baseUrl: string) => hc<AppType>(baseUrl);
+/**
+ * Creates a client for the v1 API while keeping environment variables scoped
+ * to the API origin rather than coupling deployment config to one version.
+ */
+export const createApiClient = (baseUrl: string) =>
+  hc<AppType>(resolveApiUrl(baseUrl, `${API_V1_BASE_PATH}/`));
 
 export type ApiClient = ReturnType<typeof createApiClient>;

--- a/packages/shared/src/api.test.ts
+++ b/packages/shared/src/api.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  API_AUTH_BASE_PATH,
+  API_JOB_PROGRESS_PATH,
+  API_JOBS_BASE_PATH,
+  API_V1_BASE_PATH,
+  resolveApiUrl,
+} from "./api";
+
+describe("API URL contract", () => {
+  it("derives every public path from the v1 prefix", () => {
+    expect(API_AUTH_BASE_PATH).toBe(`${API_V1_BASE_PATH}/api/auth`);
+    expect(API_JOBS_BASE_PATH).toBe(`${API_V1_BASE_PATH}/jobs`);
+    expect(API_JOB_PROGRESS_PATH).toBe(`${API_JOBS_BASE_PATH}/progress`);
+  });
+
+  it("resolves paths against an origin with or without a trailing slash", () => {
+    expect(resolveApiUrl("https://api.example.com", API_JOBS_BASE_PATH)).toBe(
+      "https://api.example.com/v1/jobs",
+    );
+    expect(resolveApiUrl("https://api.example.com/", API_AUTH_BASE_PATH)).toBe(
+      "https://api.example.com/v1/api/auth",
+    );
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -1,0 +1,17 @@
+/**
+ * Public path prefixes for the PlaylistWizard API contract.
+ *
+ * Environment variables contain only the API origin. Keeping paths here makes
+ * version changes explicit and prevents each application from composing its
+ * own variation of the public URL.
+ */
+export const API_V1_BASE_PATH = "/v1";
+export const API_AUTH_BASE_PATH = `${API_V1_BASE_PATH}/api/auth`;
+export const API_JOBS_BASE_PATH = `${API_V1_BASE_PATH}/jobs`;
+export const API_JOB_PROGRESS_PATH = `${API_JOBS_BASE_PATH}/progress`;
+
+/**
+ * Resolves a public API path against an API origin.
+ */
+export const resolveApiUrl = (apiOrigin: string, path: string): string =>
+  new URL(path, apiOrigin).toString();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./api";
+
 /**
  * Whether the given data is null or undefined.
  * @param data The data to check

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@playlistwizard/playlist-action-job':
         specifier: workspace:*
         version: link:../../packages/playlist-action-job
+      '@playlistwizard/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@sentry/cloudflare':
         specifier: 10.54.0
         version: 10.54.0(@cloudflare/workers-types@4.20260617.1)
@@ -380,6 +383,9 @@ importers:
       '@playlistwizard/playlist-action-job':
         specifier: workspace:*
         version: link:../playlist-action-job
+      '@playlistwizard/shared':
+        specifier: workspace:*
+        version: link:../shared
       hono:
         specifier: 4.12.26
         version: 4.12.26


### PR DESCRIPTION
## Summary

- mount all public API Worker routes under `/v1`
- move Better Auth and Playlist Action Job HTTP/WebSocket clients to versioned endpoints
- centralize API path constants and URL resolution in `@playlistwizard/shared`
- centralize Next.js API origin access and remove duplicated environment lookups
- update the Durable Object progress delivery ADR and add focused URL contract tests

## Why

The API previously exposed unversioned routes, which made future breaking changes unsafe. Version and URL fragments were also composed independently across the Worker, Next.js, and the RPC client, making path drift likely.

## Impact

API consumers must use `/v1` routes. `API_URL` and `NEXT_PUBLIC_API_URL` remain origin-only environment variables, so deployment configuration does not need version-specific paths.

## Validation

- `pnpm biome ci .`
- `pnpm build:packages`
- `pnpm test:coverage` (60 files, 396 tests)
- `pnpm -F @playlistwizard/api test`
- `pnpm -F @playlistwizard/api build`
- Next.js `experimental-analyze --output` with CI-equivalent environment variables