### PR TITLE
chore(shared): prevent accidental package publishing

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,10 +7,7 @@
   "files": [
     "dist"
   ],
-  "private": false,
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "scripts": {
     "dev": "tsc --watch",
     "dev:network": "tsc --watch",


### PR DESCRIPTION
## Summary
- mark `@playlistwizard/shared` as a private workspace package
- remove public publishing configuration

## Verification
- pre-commit formatting and lint checks completed successfully (existing warnings remain)