### PR TITLE
fix(www): scan shared UI classes in Tailwind

### DIFF
--- a/apps/www/src/app/global.css
+++ b/apps/www/src/app/global.css
@@ -3,6 +3,9 @@
 @import "tw-animate-css";
 @import "@playlistwizard/ui/styles/tokens.css";
 
+/* Tailwind ignores dependency packages by default, so shared UI classes must be scanned explicitly. */
+@source "../../../../packages/ui/src";
+
 @plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
## Summary
- add the shared UI package source to Tailwind CSS scanning
- restore generated styles for shared components such as the dev console feature flag switch

## Verification
- `pnpm exec biome check apps/www/src/app/global.css`
- confirmed the generated CSS includes the shared Switch size utilities