### PR TITLE
fix(skills): verify GitHub auth outside sandbox

### DIFF
--- a/.agents/skills/github/SKILL.md
+++ b/.agents/skills/github/SKILL.md
@@ -9,4 +9,7 @@ description: GitHub に関する全ての操作やこのプロジェクトの Gi
 - ALWAYS: gh を使用し、直接 curl などでは叩かないこと。gh graphql で API を叩くことは可とする。
 - ALWAYS: gh の認証が切れている場合は、ユーザーにログインのためのコマンドと一緒にログインを促すこと。
 - ALWAYS: PR のタイトルは Conventional commit 形式に従うこと。また、タイトルや本文は全て英語で記述すること。
-- ALWAYS: Codex App などの Sandbox 環境では、gh 使用時にネットワークアクセスで弾かれる場合がある。その時はユーザー確認を挟むことでネットワークアクセスの承認を得る必要がある。
+- Sandbox 環境では、通常権限での `gh auth status` の結果を確定情報として扱わないこと。
+- `token is invalid`、未認証、credential unavailable など、理由を問わず `gh` の認証確認に失敗した場合は、ユーザーにログインを依頼する前に、同じコマンドを `require_escalated` で再実行すること。
+- 権限昇格後も認証失敗した場合に限り、`gh auth login` を案内すること。
+- 「ユーザー確認を挟む」とはチャットで許可を尋ねることではなく、ツールの権限昇格リクエストを出すことを意味する。


### PR DESCRIPTION
## Summary

- require GitHub authentication failures in sandboxed environments to be rechecked with elevated permissions
- clarify that login guidance should only be shown after the elevated authentication check also fails
- define user confirmation as an explicit tool permission request

## Why

Sandboxed commands may not have access to the host credential store. Treating a normal-permission `gh auth status` failure as a confirmed expired token can incorrectly stop the workflow and ask the user to log in again.

## Impact

Agents following the GitHub skill will request sandbox permission and verify the host authentication state before concluding that GitHub credentials are invalid.

## Validation

- repository format hook passed
- repository lint hook passed with existing warnings
