### PR TITLE
fix(ci): ensure required workflows always run

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -2,11 +2,9 @@ name: Bundle Size Analysis
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   analyze:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/oxc.yml
+++ b/.github/workflows/oxc.yml
@@ -2,25 +2,12 @@ name: Lint & format
 
 on:
   pull_request:
-    paths:
-      - "packages/**"
-      - "apps/api/**"
-      - "apps/www/**"
-      - "scripts/**"
-      - ".oxfmtrc.json"
-      - ".oxlintrc.json"
-      - ".github/workflows/oxc.yml"
-      - "**/package.json"
-      - "pnpm-lock.yaml"
-    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
   oxc:
-    if: |
-      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: Release
 
 on:
   push:
-    paths:
-      - "apps/www/**"
-      - "packages/**"
-      - "**/package.json"
     branches:
       - develop
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,6 @@ name: Test
 
 on:
   pull_request:
-    paths:
-      - "packages/**"
-      - "apps/api/**"
-      - "apps/www/**"
-      - "**/package.json"
-    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -15,8 +9,6 @@ permissions:
 
 jobs:
   vitest:
-    if: |
-      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- run lint, test, and bundle analysis workflows for every pull request event
- run the release workflow for every push to `develop`
- remove path filters, restricted pull request activity types, and draft guards

## Root cause

Required checks such as `vitest` and `oxc` could be skipped by workflow-level filters. GitHub rulesets still waited for those required status checks, leaving pull requests blocked with `Expected — Waiting for status to be reported`.

## Impact

All required workflows now report a status consistently. Draft pull requests also run CI, and pushes to `develop` always run the release workflow regardless of which files changed.

## Validation

- parsed all workflow YAML files successfully
- verified workflow formatting with Oxfmt
- passed the repository commit hooks for formatting and linting
