### PR TITLE
fix(api): standardize forbidden responses

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-  "editor.defaultFormatter": "biomejs.biome",
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.biome": "explicit"
-  }
+  "editor.formatOnSaveMode": "file"
 }

--- a/apps/api/src/presentation/http/errors/forbidden.ts
+++ b/apps/api/src/presentation/http/errors/forbidden.ts
@@ -1,0 +1,5 @@
+import { Context } from "hono";
+
+export function forbidden(c: Context) {
+  return c.json({ error: "Forbidden" }, 403);
+}

--- a/apps/api/src/presentation/http/middleware.ts
+++ b/apps/api/src/presentation/http/middleware.ts
@@ -16,6 +16,7 @@ import {
   getTrustedOrigins,
   isAllowedOrigin,
 } from "../../shared/config";
+import { forbidden } from "./errors/forbidden";
 
 type AuthVariables = {
   auth: WorkerAuth;
@@ -49,7 +50,7 @@ export const requireTrustedOriginForMutation: MiddlewareHandler<{
 
   const origin = c.req.header("Origin");
   if (!isAllowedOrigin(origin, getTrustedOrigins(c.env))) {
-    return c.json({ error: "Forbidden" }, 403);
+    return forbidden(c);
   }
 
   await next();

--- a/apps/api/src/presentation/http/playlist-action-jobs/create.ts
+++ b/apps/api/src/presentation/http/playlist-action-jobs/create.ts
@@ -2,6 +2,7 @@ import { vValidator } from "@hono/valibot-validator";
 import { toAccountId } from "@playlistwizard/core";
 import { createJobRequestSchema } from "@playlistwizard/playlist-action-job";
 import { createHonoApp } from "../hono";
+import { forbidden } from "../errors/forbidden";
 
 export const jobsCreateRoute = createHonoApp().post(
   "/",
@@ -22,7 +23,7 @@ export const jobsCreateRoute = createHonoApp().post(
     });
 
     if (result.type === "account_not_found") {
-      return c.json({ error: "Forbidden" }, 403);
+      return forbidden(c);
     }
 
     if (result.type === "enqueue_failed") {

--- a/apps/api/src/presentation/http/playlist-action-jobs/progress.ts
+++ b/apps/api/src/presentation/http/playlist-action-jobs/progress.ts
@@ -2,12 +2,13 @@ import { INITIAL_SNAPSHOT_HEADER } from "@/presentation/durable-objects/playlist
 import { createHonoApp } from "@/presentation/http/hono";
 import { getTrustedOrigins, isAllowedOrigin } from "@/shared/config";
 import { JOB_PROGRESS_STREAM_CONNECT_REQUEST_URL } from "@/shared/job-progress-stream-internal-request";
+import { forbidden } from "../errors/forbidden";
 
 // /jobs/progress
 export const jobProgressRoute = createHonoApp().get("/", async (c) => {
   const origin = c.req.header("Origin");
   if (!isAllowedOrigin(origin, getTrustedOrigins(c.env))) {
-    return c.text("Forbidden", 403);
+    return forbidden(c);
   }
 
   if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {


### PR DESCRIPTION
## Summary
- centralize API forbidden responses as JSON
- use the shared response for origin and account authorization failures
- align VS Code formatting with Oxc

## Verification
- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter @playlistwizard/api build`
- `pnpm test` (60 files, 397 tests)