### PR TITLE
chore: ignore local review records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ next-env.d.ts
 
 # claude code
 .claude/settings.local.json
+
+# Local AI review records
+docs/reviews/


### PR DESCRIPTION
## Summary
- ignore locally generated AI review records under `docs/reviews/`
- keep existing local review files untouched

## Verification
- confirmed existing review records are preserved
- confirmed both records match the new ignore rule
- commit hooks completed formatting and lint checks