### PR TITLE
chore(deps): harden dependency installation

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -88,5 +88,5 @@
     "tailwindcss": "4.3.1",
     "tw-animate-css": "1.4.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.16.0"
 }

--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
       "@opentelemetry/api": "1.9.1"
     }
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.16.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 packages:
   - "packages/*"
   - "apps/*"
+
+# Dependency lifecycle scripts are disabled to prevent unreviewed package code
+# from executing during installation.
+ignoreDepScripts: true
+
+# Wait five days (5 * 24 * 60 minutes) before resolving newly published versions.
+minimumReleaseAge: 7200


### PR DESCRIPTION
## Summary

- disable dependency lifecycle scripts during pnpm installs
- require package versions to be at least five days old before resolution
- upgrade the pinned pnpm version to 10.16.0, where `minimumReleaseAge` is supported

## Why

These defaults reduce supply-chain risk by preventing unreviewed dependency code from executing during installation and by adding time for newly published malicious releases to be detected and removed.

Project lifecycle scripts remain enabled; only scripts from installed dependencies are disabled.

## Validation

- `corepack pnpm@10.16.0 config get ignoreDepScripts` → `true`
- `corepack pnpm@10.16.0 config get minimumReleaseAge` → `7200`
- `corepack pnpm@10.16.0 install --lockfile-only --frozen-lockfile --offline --ignore-scripts`
- commit hooks: `oxfmt --write .`, `oxlint .`
