### PR TITLE
chore: align Renovate release age with pnpm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,13 @@
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "description": "Mirror pnpm minimumReleaseAge so Renovate waits before creating npm update PRs that cannot refresh pnpm-lock.yaml yet.",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "5 days",
+      "prCreation": "not-pending",
+      "internalChecksFilter": "strict"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary
- Configure Renovate to wait 5 days for npm releases before creating update PRs.
- Match pnpm minimumReleaseAge so lockfile artifact updates are not blocked by immature package versions.

## Verification
- Parsed renovate.json with Node.js
- pre-commit ran oxfmt --write . and oxlint .