### PR TITLE
refactor(core): centralize structured playlists graph rules

### DIFF
--- a/apps/www/src/repository/structured-playlists/dependency.ts
+++ b/apps/www/src/repository/structured-playlists/dependency.ts
@@ -7,6 +7,11 @@ import {
   type StructuredPlaylistsDefinitionPlaylist,
 } from "@playlistwizard/core/structured-playlists";
 
+/**
+ * This Module is kept as a compatibility seam for existing www callers.
+ * New Structured Playlists code should import graph helpers directly from
+ * `@playlistwizard/core/structured-playlists` so the Definition rules stay in core.
+ */
 export type DependencyNode = StructuredPlaylistsDefinitionPlaylist;
 
 /** Detects Dependency cycles while preserving the existing www import path. */

--- a/apps/www/src/repository/structured-playlists/dependency.ts
+++ b/apps/www/src/repository/structured-playlists/dependency.ts
@@ -1,184 +1,26 @@
-import type { StructuredPlaylistsDefinition } from "@playlistwizard/core/structured-playlists";
+import {
+  groupByLevel,
+  hasDependencyCycle as coreHasDependencyCycle,
+  hasInvalidDependencies as coreHasInvalidDependencies,
+  listAllPaths,
+  type StructuredPlaylistsDefinition,
+  type StructuredPlaylistsDefinitionPlaylist,
+} from "@playlistwizard/core/structured-playlists";
 
-/**
- * Checks for dependency cycles in the playlists.
- * Returns ok() if no cycle, otherwise err with the cycle path.
- *
- * ## Dependency Cycle Detection Algorithm
- * The `noDependencyCycle` method constructs a directed graph where each playlist is a node and edges represent dependencies.
- * It then performs a DFS traversal for each node to detect cycles:
- * - If a node is revisited while still in the current DFS path (`visiting` set), a cycle is detected and the path is returned.
- * - If a node has already been fully explored (`visited` set), it is skipped.
- * - The algorithm records the traversal path to accurately report the cycle.
- * - If any cycle is found, the method returns an error with the cycle path; otherwise, it returns success.
- *
- * The class also provides utility methods to check for required fields, validate field types, and recursively validate nested playlist dependencies.
- */
+export type DependencyNode = StructuredPlaylistsDefinitionPlaylist;
+
+/** Detects Dependency cycles while preserving the existing www import path. */
 export function hasDependencyCycle(
   json: StructuredPlaylistsDefinition,
 ): boolean {
-  const graph = buildDependencyGraph(json.playlists);
-  const visited = new Set<string>();
-  const visiting = new Set<string>();
-
-  // Check each playlist for cycles using DFS
-  for (const playlistId of Object.keys(graph)) {
-    if (!visited.has(playlistId)) {
-      if (dfsHasCycle(playlistId, graph, visited, visiting)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+  return coreHasDependencyCycle({ playlists: json.playlists });
 }
 
-/**
- * Builds a dependency graph from playlists where keys are playlist IDs
- * and values are arrays of their dependency IDs
- */
-function buildDependencyGraph(
-  playlists: StructuredPlaylistsDefinition["playlists"],
-): Record<string, string[]> {
-  const graph: Record<string, string[]> = {};
-
-  function addToGraph(
-    playlist: StructuredPlaylistsDefinition["playlists"][number],
-  ): void {
-    if (!graph[playlist.id]) {
-      graph[playlist.id] = [];
-    }
-
-    if (playlist.dependencies) {
-      for (const dependency of playlist.dependencies) {
-        graph[playlist.id].push(dependency.id);
-        // Recursively add dependencies to graph
-        addToGraph(dependency);
-      }
-    }
-  }
-
-  for (const playlist of playlists) {
-    addToGraph(playlist);
-  }
-
-  return graph;
-}
-
-/**
- * Performs DFS to detect cycles in the dependency graph
- */
-function dfsHasCycle(
-  nodeId: string,
-  graph: Record<string, string[]>,
-  visited: Set<string>,
-  visiting: Set<string>,
-): boolean {
-  // Mark as currently being visited
-  visiting.add(nodeId);
-
-  // Check all dependencies
-  const dependencies = graph[nodeId] || [];
-  for (const dependencyId of dependencies) {
-    // If we encounter a node that's currently being visited, we found a cycle
-    if (visiting.has(dependencyId)) {
-      return true;
-    }
-
-    // If not visited yet, recursively check
-    if (!visited.has(dependencyId)) {
-      if (dfsHasCycle(dependencyId, graph, visited, visiting)) {
-        return true;
-      }
-    }
-  }
-
-  // Mark as fully visited and remove from visiting
-  visiting.delete(nodeId);
-  visited.add(nodeId);
-
-  return false;
-}
-
-/**
- * Detect invalid dependencies in the playlist structure.
- * For example, same playlist as a dependency, or same playlist as a sibling.
- */
+/** Detects invalid Dependency placements while preserving the existing import path. */
 export function hasInvalidDependencies(
   definition: StructuredPlaylistsDefinition,
 ): boolean {
-  // detect sibling issue
-  const levels = groupByLevel(definition.playlists);
-  for (const level of levels) {
-    const seen = new Set<string>();
-    for (const id of level) {
-      if (seen.has(id)) {
-        return true; // Sibling issue found
-      }
-      seen.add(id);
-    }
-  }
-
-  // detect self dependencies
-  const paths = listAllPaths(definition.playlists);
-  for (const path of paths) {
-    const seen = new Set<string>();
-    for (const id of path) {
-      if (seen.has(id)) {
-        return true; // Duplicate found in path
-      }
-      seen.add(id);
-    }
-  }
-
-  return false;
+  return coreHasInvalidDependencies({ playlists: definition.playlists });
 }
 
-export type DependencyNode = StructuredPlaylistsDefinition["playlists"][number];
-
-/**
- * This function exported only testing purpose
- */
-export function groupByLevel(roots: DependencyNode[]): string[][] {
-  const result: string[][] = [];
-  let currentLevel: DependencyNode[] = roots;
-
-  while (currentLevel.length > 0) {
-    result.push(currentLevel.map((n) => n.id));
-
-    const nextLevel: DependencyNode[] = [];
-    for (const node of currentLevel) {
-      if (node.dependencies) {
-        nextLevel.push(...node.dependencies);
-      }
-    }
-    currentLevel = nextLevel;
-  }
-  return result;
-}
-
-/**
- * This function exported only testing purpose
- */
-export function listAllPaths(nodes: DependencyNode[]): string[][] {
-  const result: string[][] = [];
-
-  function dfs(node: DependencyNode, path: string[]) {
-    const newPath = [...path, node.id];
-    if (!node.dependencies || node.dependencies.length === 0) {
-      // 葉ノードの場合、パスを保存
-      result.push(newPath);
-    } else {
-      // 子ノードを再帰的に探索
-      for (const child of node.dependencies) {
-        dfs(child, newPath);
-      }
-    }
-  }
-
-  for (const node of nodes) {
-    dfs(node, []);
-  }
-
-  return result;
-}
+export { groupByLevel, listAllPaths };

--- a/apps/www/src/usecase/sync-structured-playlists.ts
+++ b/apps/www/src/usecase/sync-structured-playlists.ts
@@ -1,4 +1,8 @@
-import type { StructuredPlaylistsDefinition } from "@playlistwizard/core/structured-playlists";
+import {
+  listPlaylistIds,
+  planStructuredPlaylistsSyncSteps,
+  type StructuredPlaylistsDefinition,
+} from "@playlistwizard/core/structured-playlists";
 import { err, ok, type Result } from "neverthrow";
 import { type AccountId, type PlaylistId, toPlaylistId } from "@/entities/ids";
 import type { FullPlaylist, PlaylistItem } from "@/features/playlist/entities";
@@ -170,72 +174,17 @@ export class SyncStructuredPlaylistsUsecase {
     playlistsMap: Map<string, FullPlaylist>,
     onPlannedSyncSteps?: (steps: SyncStep[]) => void,
   ): Result<SyncStep[], SyncError> {
-    const steps: SyncStep[] = [];
-    const processed = new Set<string>();
-
-    // Collect all items from entire dependency tree (including grandchildren and beyond)
-    const collectAllItems = (
-      playlist: (typeof playlists)[number],
-    ): Array<{ item: PlaylistItem; sourcePlaylistId: string }> => {
-      const allItems: Array<{ item: PlaylistItem; sourcePlaylistId: string }> =
-        [];
-
-      if (playlist.dependencies) {
-        for (const dependency of playlist.dependencies) {
-          const sourcePlaylist = playlistsMap.get(dependency.id);
-          if (sourcePlaylist) {
-            // Add items from this dependency
-            for (const item of sourcePlaylist.items) {
-              allItems.push({ item, sourcePlaylistId: dependency.id });
-            }
-            // Recursively add items from nested dependencies
-            allItems.push(...collectAllItems(dependency));
-          }
-        }
-      }
-
-      return allItems;
-    };
-
-    const processPlaylist = (playlist: (typeof playlists)[number]) => {
-      // Skip if already processed (prevent infinite loops)
-      if (processed.has(playlist.id)) return;
-
-      const targetPlaylist = playlistsMap.get(playlist.id);
-      if (!targetPlaylist) return;
-
-      // Process dependencies first (topological order)
-      if (playlist.dependencies) {
-        for (const dependency of playlist.dependencies) {
-          processPlaylist(dependency);
-        }
-      }
-
-      // Collect all items from the entire dependency tree
-      const allDependencyItems = collectAllItems(playlist);
-
-      // Add items that don't already exist in target playlist
-      for (const { item, sourcePlaylistId } of allDependencyItems) {
-        const itemExists = targetPlaylist.items.some(
-          (existingItem: PlaylistItem) => existingItem.videoId === item.videoId,
-        );
-
-        if (!itemExists) {
-          steps.push({
-            type: "add_item",
-            playlistId: toPlaylistId(playlist.id),
-            item,
-            sourcePlaylistId,
-          });
-        }
-      }
-
-      processed.add(playlist.id);
-    };
-
-    for (const playlist of playlists) {
-      processPlaylist(playlist);
-    }
+    const steps = planStructuredPlaylistsSyncSteps<
+      FullPlaylist,
+      PlaylistItem,
+      PlaylistId
+    >({
+      getItems: (playlist) => playlist.items,
+      getVideoId: (item) => item.videoId,
+      playlists,
+      playlistsMap,
+      toPlaylistId,
+    });
 
     onPlannedSyncSteps?.(steps);
     return ok(steps);
@@ -323,21 +272,7 @@ export class SyncStructuredPlaylistsUsecase {
   private getAllPlaylistIds(
     playlists: StructuredPlaylistsDefinition["playlists"],
   ): string[] {
-    const ids = new Set<string>();
-
-    function collectIds(
-      playlistArray: StructuredPlaylistsDefinition["playlists"],
-    ) {
-      for (const playlist of playlistArray) {
-        ids.add(playlist.id);
-        if (playlist.dependencies) {
-          collectIds(playlist.dependencies);
-        }
-      }
-    }
-
-    collectIds(playlists);
-    return Array.from(ids);
+    return listPlaylistIds(playlists);
   }
 }
 

--- a/packages/core/src/structured-playlists/graph.test.ts
+++ b/packages/core/src/structured-playlists/graph.test.ts
@@ -44,6 +44,24 @@ describe("Structured Playlists Definition graph", () => {
     expect(hasDependencyCycle(definition)).toBe(true);
   });
 
+  it("handles Playlist IDs that match object prototype property names", () => {
+    const definition: StructuredPlaylistsDefinition = {
+      ...baseDefinition,
+      playlists: [
+        {
+          id: "__proto__",
+          dependencies: [{ id: "constructor" }],
+        },
+        {
+          id: "constructor",
+          dependencies: [{ id: "__proto__" }],
+        },
+      ],
+    };
+
+    expect(hasDependencyCycle(definition)).toBe(true);
+  });
+
   it("allows shared Dependencies when no cycle exists", () => {
     const definition: StructuredPlaylistsDefinition = {
       ...baseDefinition,

--- a/packages/core/src/structured-playlists/graph.test.ts
+++ b/packages/core/src/structured-playlists/graph.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import type { StructuredPlaylistsDefinition } from "./schema";
+import {
+  groupByLevel,
+  hasDependencyCycle,
+  hasInvalidDependencies,
+  listAllPaths,
+  listPlaylistIds,
+  planStructuredPlaylistsSyncSteps,
+} from "./graph";
+
+const baseDefinition: Omit<StructuredPlaylistsDefinition, "playlists"> = {
+  version: 1,
+  name: "Test Definition",
+  provider: "google",
+};
+
+type PlaylistItem = {
+  id: string;
+  videoId: string;
+};
+
+type FullPlaylist = {
+  id: string;
+  items: PlaylistItem[];
+};
+
+describe("Structured Playlists Definition graph", () => {
+  it("detects Dependency cycles across nested and sibling Playlist definitions", () => {
+    const definition: StructuredPlaylistsDefinition = {
+      ...baseDefinition,
+      playlists: [
+        {
+          id: "playlist1",
+          dependencies: [{ id: "playlist2" }],
+        },
+        {
+          id: "playlist2",
+          dependencies: [{ id: "playlist1" }],
+        },
+      ],
+    };
+
+    expect(hasDependencyCycle(definition)).toBe(true);
+  });
+
+  it("allows shared Dependencies when no cycle exists", () => {
+    const definition: StructuredPlaylistsDefinition = {
+      ...baseDefinition,
+      playlists: [
+        {
+          id: "root1",
+          dependencies: [{ id: "shared" }],
+        },
+        {
+          id: "root2",
+          dependencies: [{ id: "shared" }],
+        },
+      ],
+    };
+
+    expect(hasDependencyCycle(definition)).toBe(false);
+  });
+
+  it("detects duplicate sibling Dependencies and duplicate path entries", () => {
+    expect(
+      hasInvalidDependencies({
+        ...baseDefinition,
+        playlists: [
+          {
+            id: "playlist1",
+            dependencies: [{ id: "playlist2" }, { id: "playlist2" }],
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      hasInvalidDependencies({
+        ...baseDefinition,
+        playlists: [
+          {
+            id: "playlist1",
+            dependencies: [
+              {
+                id: "playlist2",
+                dependencies: [{ id: "playlist1" }],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps traversal helpers stable for existing callers", () => {
+    const roots = [
+      {
+        id: "root",
+        dependencies: [
+          {
+            id: "a",
+            dependencies: [{ id: "a1" }, { id: "a2" }],
+          },
+          { id: "b" },
+        ],
+      },
+    ];
+
+    expect(groupByLevel(roots)).toEqual([["root"], ["a", "b"], ["a1", "a2"]]);
+    expect(listAllPaths(roots)).toEqual([
+      ["root", "a", "a1"],
+      ["root", "a", "a2"],
+      ["root", "b"],
+    ]);
+  });
+
+  it("lists Playlist IDs in first-seen traversal order with duplicates collapsed", () => {
+    expect(
+      listPlaylistIds([
+        {
+          id: "playlist1",
+          dependencies: [{ id: "playlist2" }],
+        },
+        {
+          id: "playlist1",
+          dependencies: [{ id: "playlist2" }, { id: "playlist3" }],
+        },
+      ]),
+    ).toEqual(["playlist1", "playlist2", "playlist3"]);
+  });
+
+  it("plans Sync add-item steps from Dependency Playlists without mutating target state", () => {
+    const item1 = { id: "item1", videoId: "video1" };
+    const duplicateVideo = { id: "item2", videoId: "video1" };
+    const item3 = { id: "item3", videoId: "video3" };
+    const playlists = [
+      {
+        id: "target",
+        dependencies: [{ id: "source1" }, { id: "source2" }],
+      },
+    ];
+    const playlistsMap = new Map<string, FullPlaylist>([
+      ["target", { id: "target", items: [] }],
+      ["source1", { id: "source1", items: [item1] }],
+      ["source2", { id: "source2", items: [duplicateVideo, item3] }],
+    ]);
+
+    expect(
+      planStructuredPlaylistsSyncSteps({
+        getItems: (playlist) => playlist.items,
+        getVideoId: (item) => item.videoId,
+        playlists,
+        playlistsMap,
+        toPlaylistId: (playlistId) => playlistId,
+      }),
+    ).toEqual([
+      {
+        type: "add_item",
+        playlistId: "target",
+        item: item1,
+        sourcePlaylistId: "source1",
+      },
+      {
+        type: "add_item",
+        playlistId: "target",
+        item: duplicateVideo,
+        sourcePlaylistId: "source2",
+      },
+      {
+        type: "add_item",
+        playlistId: "target",
+        item: item3,
+        sourcePlaylistId: "source2",
+      },
+    ]);
+  });
+});

--- a/packages/core/src/structured-playlists/graph.ts
+++ b/packages/core/src/structured-playlists/graph.ts
@@ -35,7 +35,7 @@ export function hasDependencyCycle(input: {
   const visited = new Set<string>();
   const visiting = new Set<string>();
 
-  for (const playlistId of Object.keys(graph)) {
+  for (const playlistId of graph.keys()) {
     if (!visited.has(playlistId)) {
       if (dfsHasCycle(playlistId, graph, visited, visiting)) {
         return true;
@@ -214,17 +214,17 @@ export function listAllPaths(nodes: DependencyNode[]): string[][] {
 
 function buildDependencyGraph(
   playlists: StructuredPlaylistsDefinitionPlaylist[],
-): Record<string, string[]> {
-  const graph: Record<string, string[]> = {};
+): Map<string, string[]> {
+  const graph = new Map<string, string[]>();
 
   function addToGraph(playlist: StructuredPlaylistsDefinitionPlaylist): void {
-    if (!graph[playlist.id]) {
-      graph[playlist.id] = [];
+    if (!graph.has(playlist.id)) {
+      graph.set(playlist.id, []);
     }
 
     if (playlist.dependencies) {
       for (const dependency of playlist.dependencies) {
-        graph[playlist.id].push(dependency.id);
+        graph.get(playlist.id)?.push(dependency.id);
         addToGraph(dependency);
       }
     }
@@ -239,13 +239,13 @@ function buildDependencyGraph(
 
 function dfsHasCycle(
   nodeId: string,
-  graph: Record<string, string[]>,
+  graph: Map<string, string[]>,
   visited: Set<string>,
   visiting: Set<string>,
 ): boolean {
   visiting.add(nodeId);
 
-  for (const dependencyId of graph[nodeId] || []) {
+  for (const dependencyId of graph.get(nodeId) || []) {
     if (visiting.has(dependencyId)) return true;
 
     if (!visited.has(dependencyId)) {

--- a/packages/core/src/structured-playlists/graph.ts
+++ b/packages/core/src/structured-playlists/graph.ts
@@ -2,6 +2,12 @@ import type { StructuredPlaylistsDefinitionPlaylist } from "./schema";
 
 export type DependencyNode = StructuredPlaylistsDefinitionPlaylist;
 
+/**
+ * Sync planning output for the legacy in-process Sync implementation.
+ * This is not the canonical Playlist Action Job Step type. When Sync moves into
+ * Playlist Action Jobs, define new Step payloads for that execution contract
+ * instead of reusing this legacy planning shape.
+ */
 export type StructuredPlaylistsSyncStep<TPlaylistId, TItem> = {
   type: "add_item";
   playlistId: TPlaylistId;

--- a/packages/core/src/structured-playlists/graph.ts
+++ b/packages/core/src/structured-playlists/graph.ts
@@ -1,0 +1,256 @@
+import type { StructuredPlaylistsDefinitionPlaylist } from "./schema";
+
+export type DependencyNode = StructuredPlaylistsDefinitionPlaylist;
+
+export type StructuredPlaylistsSyncStep<TPlaylistId, TItem> = {
+  type: "add_item";
+  playlistId: TPlaylistId;
+  item: TItem;
+  sourcePlaylistId: string;
+};
+
+type PlanStructuredPlaylistsSyncStepsInput<TPlaylist, TItem, TPlaylistId> = {
+  playlists: StructuredPlaylistsDefinitionPlaylist[];
+  playlistsMap: Map<string, TPlaylist>;
+  getItems: (playlist: TPlaylist) => TItem[];
+  getVideoId: (item: TItem) => string;
+  toPlaylistId: (playlistId: string) => TPlaylistId;
+};
+
+/**
+ * Detects whether a Structured Playlists Definition contains a Dependency cycle.
+ * Keeping this in core makes the Definition graph invariant shared by editor,
+ * import, storage, and Sync code instead of re-implementing traversal per caller.
+ */
+export function hasDependencyCycle(input: {
+  playlists: StructuredPlaylistsDefinitionPlaylist[];
+}): boolean {
+  const graph = buildDependencyGraph(input.playlists);
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  for (const playlistId of Object.keys(graph)) {
+    if (!visited.has(playlistId)) {
+      if (dfsHasCycle(playlistId, graph, visited, visiting)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Detects duplicate Dependency placements that make a Definition ambiguous.
+ * The current product rules reject duplicate sibling IDs and repeated IDs on a
+ * single root-to-leaf path; this preserves that behavior in one core Module.
+ */
+export function hasInvalidDependencies(input: {
+  playlists: StructuredPlaylistsDefinitionPlaylist[];
+}): boolean {
+  for (const level of groupByLevel(input.playlists)) {
+    const seen = new Set<string>();
+    for (const id of level) {
+      if (seen.has(id)) return true;
+      seen.add(id);
+    }
+  }
+
+  for (const path of listAllPaths(input.playlists)) {
+    const seen = new Set<string>();
+    for (const id of path) {
+      if (seen.has(id)) return true;
+      seen.add(id);
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Lists every Playlist ID referenced by a Definition in first-seen traversal
+ * order. Duplicate IDs collapse to the first occurrence, matching the previous
+ * Sync fetch behavior.
+ */
+export function listPlaylistIds(
+  playlists: StructuredPlaylistsDefinitionPlaylist[],
+): string[] {
+  const ids = new Set<string>();
+
+  function collectIds(playlistArray: StructuredPlaylistsDefinitionPlaylist[]) {
+    for (const playlist of playlistArray) {
+      ids.add(playlist.id);
+      if (playlist.dependencies) {
+        collectIds(playlist.dependencies);
+      }
+    }
+  }
+
+  collectIds(playlists);
+  return Array.from(ids);
+}
+
+/**
+ * Plans Sync add-item work from a Definition and fetched Playlists.
+ * The planner intentionally checks only the target Playlist's current Videos;
+ * it does not simulate added items, preserving existing duplicate behavior
+ * across multiple Dependencies.
+ */
+export function planStructuredPlaylistsSyncSteps<TPlaylist, TItem, TPlaylistId>(
+  input: PlanStructuredPlaylistsSyncStepsInput<TPlaylist, TItem, TPlaylistId>,
+): StructuredPlaylistsSyncStep<TPlaylistId, TItem>[] {
+  const steps: StructuredPlaylistsSyncStep<TPlaylistId, TItem>[] = [];
+  const processed = new Set<string>();
+
+  const collectAllItems = (
+    playlist: StructuredPlaylistsDefinitionPlaylist,
+  ): Array<{ item: TItem; sourcePlaylistId: string }> => {
+    const allItems: Array<{ item: TItem; sourcePlaylistId: string }> = [];
+
+    if (playlist.dependencies) {
+      for (const dependency of playlist.dependencies) {
+        const sourcePlaylist = input.playlistsMap.get(dependency.id);
+        if (sourcePlaylist) {
+          for (const item of input.getItems(sourcePlaylist)) {
+            allItems.push({ item, sourcePlaylistId: dependency.id });
+          }
+          allItems.push(...collectAllItems(dependency));
+        }
+      }
+    }
+
+    return allItems;
+  };
+
+  const processPlaylist = (playlist: StructuredPlaylistsDefinitionPlaylist) => {
+    if (processed.has(playlist.id)) return;
+
+    const targetPlaylist = input.playlistsMap.get(playlist.id);
+    if (!targetPlaylist) return;
+
+    if (playlist.dependencies) {
+      for (const dependency of playlist.dependencies) {
+        processPlaylist(dependency);
+      }
+    }
+
+    const targetVideoIds = new Set(
+      input.getItems(targetPlaylist).map(input.getVideoId),
+    );
+
+    for (const { item, sourcePlaylistId } of collectAllItems(playlist)) {
+      if (!targetVideoIds.has(input.getVideoId(item))) {
+        steps.push({
+          type: "add_item",
+          playlistId: input.toPlaylistId(playlist.id),
+          item,
+          sourcePlaylistId,
+        });
+      }
+    }
+
+    processed.add(playlist.id);
+  };
+
+  for (const playlist of input.playlists) {
+    processPlaylist(playlist);
+  }
+
+  return steps;
+}
+
+/**
+ * Groups Definition nodes by tree depth for duplicate sibling detection.
+ */
+export function groupByLevel(roots: DependencyNode[]): string[][] {
+  const result: string[][] = [];
+  let currentLevel: DependencyNode[] = roots;
+
+  while (currentLevel.length > 0) {
+    result.push(currentLevel.map((n) => n.id));
+
+    const nextLevel: DependencyNode[] = [];
+    for (const node of currentLevel) {
+      if (node.dependencies) {
+        nextLevel.push(...node.dependencies);
+      }
+    }
+    currentLevel = nextLevel;
+  }
+
+  return result;
+}
+
+/**
+ * Lists root-to-leaf paths for duplicate path detection.
+ */
+export function listAllPaths(nodes: DependencyNode[]): string[][] {
+  const result: string[][] = [];
+
+  function dfs(node: DependencyNode, path: string[]) {
+    const newPath = [...path, node.id];
+    if (!node.dependencies || node.dependencies.length === 0) {
+      result.push(newPath);
+      return;
+    }
+
+    for (const child of node.dependencies) {
+      dfs(child, newPath);
+    }
+  }
+
+  for (const node of nodes) {
+    dfs(node, []);
+  }
+
+  return result;
+}
+
+function buildDependencyGraph(
+  playlists: StructuredPlaylistsDefinitionPlaylist[],
+): Record<string, string[]> {
+  const graph: Record<string, string[]> = {};
+
+  function addToGraph(playlist: StructuredPlaylistsDefinitionPlaylist): void {
+    if (!graph[playlist.id]) {
+      graph[playlist.id] = [];
+    }
+
+    if (playlist.dependencies) {
+      for (const dependency of playlist.dependencies) {
+        graph[playlist.id].push(dependency.id);
+        addToGraph(dependency);
+      }
+    }
+  }
+
+  for (const playlist of playlists) {
+    addToGraph(playlist);
+  }
+
+  return graph;
+}
+
+function dfsHasCycle(
+  nodeId: string,
+  graph: Record<string, string[]>,
+  visited: Set<string>,
+  visiting: Set<string>,
+): boolean {
+  visiting.add(nodeId);
+
+  for (const dependencyId of graph[nodeId] || []) {
+    if (visiting.has(dependencyId)) return true;
+
+    if (!visited.has(dependencyId)) {
+      if (dfsHasCycle(dependencyId, graph, visited, visiting)) {
+        return true;
+      }
+    }
+  }
+
+  visiting.delete(nodeId);
+  visited.add(nodeId);
+
+  return false;
+}

--- a/packages/core/src/structured-playlists/index.ts
+++ b/packages/core/src/structured-playlists/index.ts
@@ -1,1 +1,2 @@
+export * from "./graph";
 export * from "./schema";

--- a/packages/core/src/structured-playlists/schema.ts
+++ b/packages/core/src/structured-playlists/schema.ts
@@ -20,3 +20,6 @@ export const StructuredPlaylistsDefinitionSchema = z.object({
 export type StructuredPlaylistsDefinition = z.infer<
   typeof StructuredPlaylistsDefinitionSchema
 >;
+
+export type StructuredPlaylistsDefinitionPlaylist =
+  StructuredPlaylistsDefinition["playlists"][number];


### PR DESCRIPTION
## Summary

- Add a core Structured Playlists Definition graph module for Dependency validation, traversal, Playlist ID listing, and Sync planning.
- Keep existing `apps/www` import paths as compatibility wrappers so current callers do not need to change.
- Move Sync planning implementation behind the shared core graph module while preserving existing callback and result behavior.

## Why

Structured Playlists rules were split across schema, dependency validation, editor helper code, and Sync planning. Centralizing the pure graph rules in `@playlistwizard/core` improves locality without changing the user-facing behavior of Sync or editor validation.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm build:packages`
- `pnpm build:api`
- `pnpm test:coverage`
- `pnpm -F @playlistwizard/core test`
- `pnpm -F @playlistwizard/www test -- src/repository/structured-playlists/dependency.test.ts src/usecase/sync-structured-playlists.test.ts src/features/structured-playlists-editor/libs/dependency-tree/node.test.ts`
- `DATABASE_URL=postgres://postgres:password@localhost:5432/postgres API_URL=http://localhost:3000 BETTER_AUTH_SECRET=dummy-secret-for-local-build NEXT_PUBLIC_API_URL=http://localhost:3000 GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy NEXT_TELEMETRY_DISABLED=1 pnpm -F @playlistwizard/www exec next build`

Note: `pnpm -F @playlistwizard/www build` was also attempted, but the local migration step could not connect to PostgreSQL on `localhost:5432` in this environment. The migration-free Next.js build completed successfully.
