### PR TITLE
fix(auth): align Better Auth user schema mapping

### DIFF
--- a/apps/api/src/infrastructure/auth/better-auth.ts
+++ b/apps/api/src/infrastructure/auth/better-auth.ts
@@ -1,4 +1,5 @@
 import { toUserId, type UserId } from "@playlistwizard/core/ids";
+import { betterAuthUserAdditionalFields } from "@playlistwizard/db";
 import * as schema from "@playlistwizard/db";
 import { API_AUTH_BASE_PATH } from "@playlistwizard/shared";
 import { betterAuth } from "better-auth";
@@ -54,15 +55,7 @@ export const createAuth = (
     },
     user: {
       deleteUser: { enabled: true },
-      additionalFields: {
-        isDeveloper: {
-          type: "boolean",
-          fieldName: "is_developer",
-          input: false,
-          required: false,
-          defaultValue: false,
-        },
-      },
+      additionalFields: betterAuthUserAdditionalFields,
     },
     advanced: {
       cookiePrefix: resolveAuthCookiePrefix(env.AUTH_COOKIE_PREFIX),

--- a/apps/www/src/lib/auth.ts
+++ b/apps/www/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import { betterAuthUserAdditionalFields } from "@playlistwizard/db";
 import { API_AUTH_BASE_PATH } from "@playlistwizard/shared";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -34,15 +35,7 @@ export const auth = betterAuth({
   },
   user: {
     deleteUser: { enabled: true },
-    additionalFields: {
-      isDeveloper: {
-        type: "boolean",
-        fieldName: "is_developer",
-        input: false,
-        required: false,
-        defaultValue: false,
-      },
-    },
+    additionalFields: betterAuthUserAdditionalFields,
   },
   advanced: {
     cookiePrefix: getAuthCookiePrefix(),

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "dev": "tsc --watch",
     "dev:network": "tsc --watch",
+    "test": "vitest run",
     "build": "tsc",
     "migrate": "pnpm -w migrate",
     "generate": "pnpm -w generate"

--- a/packages/db/src/better-auth.test.ts
+++ b/packages/db/src/better-auth.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import {
+  betterAuthUserAdditionalFieldNames,
+  hasBetterAuthUserAdditionalField,
+} from "./better-auth";
+
+describe("Better Auth schema mapping", () => {
+  it("maps additional user fields to Drizzle table properties", () => {
+    expect(
+      betterAuthUserAdditionalFieldNames.every((fieldName) =>
+        hasBetterAuthUserAdditionalField(fieldName),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/db/src/better-auth.ts
+++ b/packages/db/src/better-auth.ts
@@ -1,0 +1,20 @@
+import { user } from "./schema";
+
+export const betterAuthUserAdditionalFields = {
+  isDeveloper: {
+    type: "boolean",
+    // The Drizzle adapter resolves fieldName against the table object's
+    // property key. The SQL column name remains defined by schema.user.
+    fieldName: "isDeveloper",
+    input: false,
+    required: false,
+    defaultValue: false,
+  },
+} as const;
+
+export const betterAuthUserAdditionalFieldNames = Object.values(
+  betterAuthUserAdditionalFields,
+).map((field) => field.fieldName);
+
+export const hasBetterAuthUserAdditionalField = (fieldName: string): boolean =>
+  fieldName in user;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./schema";
+export * from "./better-auth";

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -13,5 +13,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/packages/db/vitest.config.mts
+++ b/packages/db/vitest.config.mts
@@ -1,0 +1,13 @@
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    exclude: ["dist/**", "node_modules/**"],
+    coverage: {
+      reporter: ["text", "json"],
+      reportOnFailure: true,
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- align Better Auth user additional field mapping with the Drizzle user schema property
- share the additional user field config from @playlistwizard/db across API and www
- add a db package regression test for Better Auth additional field mappings

## Verification
- corepack pnpm -F @playlistwizard/db build
- corepack pnpm -F @playlistwizard/db test
- corepack pnpm -F @playlistwizard/api typecheck
- corepack pnpm format:check
- corepack pnpm lint

Note: apps/www tsc --noEmit still fails on pre-existing test const assertion errors unrelated to this auth change.