### PR TITLE
fix(api): capture Better Auth errors in Sentry

### DIFF
--- a/apps/api/src/infrastructure/auth/better-auth.test.ts
+++ b/apps/api/src/infrastructure/auth/better-auth.test.ts
@@ -1,10 +1,38 @@
 import type { UserId } from "@playlistwizard/core/ids";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
   type AuthSession,
+  betterAuthLogger,
   resolveAuthCookiePrefix,
   resolveSessionCookieName,
 } from "./better-auth";
+
+const sentryMocks = vi.hoisted(() => {
+  const scope = {
+    setContext: vi.fn(),
+    setTag: vi.fn(),
+  };
+
+  return {
+    captureException: vi.fn(),
+    scope,
+    withScope: vi.fn((callback: (scopeArg: typeof scope) => void) => {
+      callback(scope);
+    }),
+  };
+});
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException: sentryMocks.captureException,
+  withScope: sentryMocks.withScope,
+}));
+
+beforeEach(() => {
+  sentryMocks.captureException.mockClear();
+  sentryMocks.scope.setContext.mockClear();
+  sentryMocks.scope.setTag.mockClear();
+  sentryMocks.withScope.mockClear();
+});
 
 describe("auth cookie helpers", () => {
   it("uses the Better Auth default cookie prefix when unset", () => {
@@ -21,6 +49,41 @@ describe("auth cookie helpers", () => {
       "__Secure-better-auth-dev.session_token",
       "better-auth-dev.session_token",
     ]);
+  });
+});
+
+describe("Better Auth observability", () => {
+  it("captures Better Auth error logs in Sentry without raw object values", () => {
+    const error = new Error("database schema mismatch");
+
+    betterAuthLogger.log("error", "Failed to create user", error, {
+      code: "oauth-code",
+      state: "oauth-state",
+    });
+
+    expect(sentryMocks.scope.setTag).toHaveBeenCalledWith(
+      "component",
+      "better-auth",
+    );
+    expect(sentryMocks.scope.setTag).toHaveBeenCalledWith(
+      "auth_system",
+      "better-auth",
+    );
+    expect(sentryMocks.scope.setContext).toHaveBeenCalledWith("better_auth", {
+      message: "Failed to create user",
+      args: [
+        expect.objectContaining({
+          message: "database schema mismatch",
+          name: "Error",
+          type: "Error",
+        }),
+        {
+          keys: ["code", "state"],
+          type: "Object",
+        },
+      ],
+    });
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
   });
 });
 

--- a/apps/api/src/infrastructure/auth/better-auth.ts
+++ b/apps/api/src/infrastructure/auth/better-auth.ts
@@ -2,6 +2,7 @@ import { toUserId, type UserId } from "@playlistwizard/core/ids";
 import { betterAuthUserAdditionalFields } from "@playlistwizard/db";
 import * as schema from "@playlistwizard/db";
 import { API_AUTH_BASE_PATH } from "@playlistwizard/shared";
+import * as Sentry from "@sentry/cloudflare";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import type { Env } from "../../env";
@@ -9,9 +10,104 @@ import { getTrustedOrigins, parseBooleanEnv } from "../../shared/config";
 import type { Db } from "../db/connection";
 
 const DEFAULT_AUTH_COOKIE_PREFIX = "better-auth";
+const MAX_BETTER_AUTH_LOG_ARG_COUNT = 5;
+const MAX_BETTER_AUTH_LOG_STRING_LENGTH = 500;
 
 export const resolveAuthCookiePrefix = (prefix?: string): string =>
   prefix?.trim() || DEFAULT_AUTH_COOKIE_PREFIX;
+
+type BetterAuthLogLevel = "debug" | "info" | "warn" | "error";
+
+type BetterAuthLogArgSummary =
+  | string
+  | number
+  | boolean
+  | null
+  | {
+      type: string;
+      name?: string;
+      message?: string;
+      stack?: string;
+      keys?: string[];
+    };
+
+const truncateBetterAuthLogString = (value: string): string =>
+  value.length > MAX_BETTER_AUTH_LOG_STRING_LENGTH
+    ? `${value.slice(0, MAX_BETTER_AUTH_LOG_STRING_LENGTH)}...`
+    : value;
+
+const summarizeBetterAuthLogArg = (arg: unknown): BetterAuthLogArgSummary => {
+  if (arg === null) return null;
+
+  if (
+    typeof arg === "string" ||
+    typeof arg === "number" ||
+    typeof arg === "boolean"
+  ) {
+    return typeof arg === "string" ? truncateBetterAuthLogString(arg) : arg;
+  }
+
+  if (arg instanceof Error) {
+    return {
+      type: "Error",
+      name: arg.name,
+      message: truncateBetterAuthLogString(arg.message),
+      stack: arg.stack ? truncateBetterAuthLogString(arg.stack) : undefined,
+    };
+  }
+
+  if (typeof arg === "object") {
+    return {
+      type: arg.constructor?.name ?? "Object",
+      keys: Object.keys(arg).slice(0, 20),
+    };
+  }
+
+  return {
+    type: typeof arg,
+  };
+};
+
+const summarizeBetterAuthLogArgs = (
+  args: unknown[],
+): BetterAuthLogArgSummary[] =>
+  args
+    .slice(0, MAX_BETTER_AUTH_LOG_ARG_COUNT)
+    .map((arg) => summarizeBetterAuthLogArg(arg));
+
+const findBetterAuthErrorArg = (args: unknown[]): Error | null => {
+  for (const arg of args) {
+    if (arg instanceof Error) return arg;
+  }
+
+  return null;
+};
+
+const captureBetterAuthError = (
+  message: string,
+  args: unknown[] = [],
+): void => {
+  const error = findBetterAuthErrorArg(args) ?? new Error(message);
+
+  Sentry.withScope((scope) => {
+    scope.setTag("component", "better-auth");
+    scope.setTag("auth_system", "better-auth");
+    scope.setContext("better_auth", {
+      message: truncateBetterAuthLogString(message),
+      args: summarizeBetterAuthLogArgs(args),
+    });
+    Sentry.captureException(error);
+  });
+};
+
+export const betterAuthLogger = {
+  level: "warn",
+  log(level: BetterAuthLogLevel, message: string, ...args: unknown[]) {
+    if (level === "error") {
+      captureBetterAuthError(message, args);
+    }
+  },
+} as const;
 
 export const createAuth = (
   db: Db,
@@ -33,6 +129,12 @@ export const createAuth = (
     basePath: API_AUTH_BASE_PATH,
     secret: env.BETTER_AUTH_SECRET,
     database: drizzleAdapter(db, { provider: "pg", schema }),
+    logger: betterAuthLogger,
+    onAPIError: {
+      onError(error) {
+        captureBetterAuthError("Better Auth API error", [error]);
+      },
+    },
     trustedOrigins: getTrustedOrigins(env),
     socialProviders: {
       google: {


### PR DESCRIPTION
## Summary
- route Better Auth error logs from the API Worker into Sentry
- capture Better Auth API errors via onAPIError
- summarize log arguments without sending raw object values such as OAuth state/code data

## Verification
- corepack pnpm -F @playlistwizard/api test -- src/infrastructure/auth/better-auth.test.ts
- corepack pnpm -F @playlistwizard/api typecheck
- corepack pnpm format:check
- corepack pnpm lint