### PR TITLE
fix(api): reduce queue batch timeout

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -16,14 +16,14 @@ queue = "playlist-action-job"
 [[queues.consumers]]
 queue = "playlist-action-job"
 max_batch_size = 3
-max_batch_timeout = 5
+max_batch_timeout = 1
 max_retries = 3
 dead_letter_queue = "playlist-action-job-dlq"
 
 [[queues.consumers]]
 queue = "playlist-action-job-dlq"
 max_batch_size = 3
-max_batch_timeout = 5
+max_batch_timeout = 1
 max_retries = 1
 
 [[durable_objects.bindings]]
@@ -51,14 +51,14 @@ queue = "playlist-action-job-dev"
 [[env.dev.queues.consumers]]
 queue = "playlist-action-job-dev"
 max_batch_size = 3
-max_batch_timeout = 5
+max_batch_timeout = 1
 max_retries = 3
 dead_letter_queue = "playlist-action-job-dev-dlq"
 
 [[env.dev.queues.consumers]]
 queue = "playlist-action-job-dev-dlq"
 max_batch_size = 3
-max_batch_timeout = 5
+max_batch_timeout = 1
 max_retries = 1
 
 [[env.dev.durable_objects.bindings]]
@@ -82,14 +82,14 @@ queue = "playlist-action-job"
 [[env.production.queues.consumers]]
 queue = "playlist-action-job"
 max_batch_size = 3
-max_batch_timeout = 5
+max_batch_timeout = 1
 max_retries = 3
 dead_letter_queue = "playlist-action-job-dlq"
 
 [[env.production.queues.consumers]]
 queue = "playlist-action-job-dlq"
 max_batch_size = 3
-max_batch_timeout = 5
+max_batch_timeout = 1
 max_retries = 1
 
 [[env.production.durable_objects.bindings]]


### PR DESCRIPTION
## Summary
- Reduce Cloudflare Queue batch timeout from 5s to 1s for playlist action job consumers.
- Apply the same timeout to local, dev, production, and DLQ consumers.

## Why
This reduces the time a single-message Playlist Action Job can remain pending before a queue consumer starts processing it.

## Validation
- pnpm exec oxfmt --check apps/api/wrangler.toml
- pnpm -F @playlistwizard/api typecheck
- pre-commit hook: pnpm format, pnpm lint