### PR TITLE
fix(api): customize Better Auth error page

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/cloudflare";
 import { Hono } from "hono";
 import type { Env } from "./env";
 import { createHonoApp } from "./presentation/http/hono";
+import { authError } from "./presentation/http/auth-error";
 import {
   createCorsMiddleware,
   injectVariables,
@@ -13,6 +14,7 @@ import { jobsRoute } from "./presentation/http/playlist-action-jobs/routes";
 // v1 contract without exposing the unversioned Worker root as a public API.
 const v1App = createHonoApp()
   .use("*", createCorsMiddleware())
+  .get("/api/auth/error", authError)
   .use("*", injectVariables)
   .on(["GET", "POST"], "/api/auth/*", (c) => c.get("auth").handler(c.req.raw))
   .route("/jobs", jobsRoute)

--- a/apps/api/src/infrastructure/auth/better-auth.ts
+++ b/apps/api/src/infrastructure/auth/better-auth.ts
@@ -1,7 +1,7 @@
 import { toUserId, type UserId } from "@playlistwizard/core/ids";
 import { betterAuthUserAdditionalFields } from "@playlistwizard/db";
 import * as schema from "@playlistwizard/db";
-import { API_AUTH_BASE_PATH } from "@playlistwizard/shared";
+import { API_AUTH_BASE_PATH, resolveApiUrl } from "@playlistwizard/shared";
 import * as Sentry from "@sentry/cloudflare";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -131,6 +131,7 @@ export const createAuth = (
     database: drizzleAdapter(db, { provider: "pg", schema }),
     logger: betterAuthLogger,
     onAPIError: {
+      errorURL: resolveApiUrl(env.API_URL, `${API_AUTH_BASE_PATH}/error`),
       onError(error) {
         captureBetterAuthError("Better Auth API error", [error]);
       },

--- a/apps/api/src/presentation/http/auth-error.test.ts
+++ b/apps/api/src/presentation/http/auth-error.test.ts
@@ -1,0 +1,45 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { Env } from "../../env";
+import { authError, renderAuthErrorPage } from "./auth-error";
+
+const env = {
+  SENTRY_ENVIRONMENT: "local",
+} as Env;
+
+describe("auth error page", () => {
+  it("renders a generic auth error page and the GitHub Issue path", () => {
+    const html = renderAuthErrorPage();
+
+    expect(html).toContain("Oops! Something Went Wrong");
+    expect(html).toContain(
+      "We're sorry, but something unexpected happened. Please try again in a moment.",
+    );
+    expect(html).toContain("issues/new?template=bug.yml");
+  });
+
+  it("does not render Better Auth error details", () => {
+    const html = renderAuthErrorPage();
+
+    expect(html).not.toContain("エラー詳細:");
+    expect(html).not.toContain("invalid_code");
+    expect(html).not.toContain("OAuth failed");
+  });
+
+  it("handles the Better Auth error endpoint without creating auth state", async () => {
+    const app = new Hono<{ Bindings: Env }>();
+    app.get("/api/auth/error", authError);
+
+    const response = await app.request(
+      "/api/auth/error?error=no_code&error_description=Missing%20code",
+      undefined,
+      env,
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(html).not.toContain("no_code");
+    expect(html).not.toContain("Missing code");
+  });
+});

--- a/apps/api/src/presentation/http/auth-error.ts
+++ b/apps/api/src/presentation/http/auth-error.ts
@@ -1,0 +1,112 @@
+import type { Context } from "hono";
+import type { Env } from "../../env";
+
+const GITHUB_BUG_ISSUE_URL =
+  "https://github.com/suzuki3jp/playlistwizard/issues/new?template=bug.yml";
+
+// Mirrors the English generic error copy in apps/www/src/features/error/view.tsx.
+// Keep both pages aligned because Better Auth callback failures render outside Next.js.
+export const renderAuthErrorPage = (): string => `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PlaylistWizard Auth Error</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        background: #030712;
+        color: #ffffff;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      main {
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        padding: 32px 16px;
+      }
+
+      section {
+        width: 100%;
+        max-width: 448px;
+        text-align: center;
+      }
+
+      .icon-wrap {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 24px;
+      }
+
+      .icon {
+        display: flex;
+        width: 80px;
+        height: 80px;
+        align-items: center;
+        justify-content: center;
+        border-radius: 9999px;
+        background: rgb(239 68 68 / 20%);
+        color: #ef4444;
+        font-size: 42px;
+        font-weight: 700;
+        line-height: 1;
+      }
+
+      h1 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        font-weight: 700;
+        letter-spacing: 0;
+      }
+
+      p {
+        margin: 0;
+        color: #9ca3af;
+        line-height: 1.6;
+      }
+
+      .support {
+        margin-top: 32px;
+        border-top: 1px solid #1f2937;
+        padding-top: 32px;
+        font-size: 14px;
+      }
+
+      a {
+        color: #f472b6;
+        text-decoration: none;
+      }
+
+      a:hover {
+        color: #f9a8d4;
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section aria-labelledby="auth-error-title">
+        <div class="icon-wrap" aria-hidden="true">
+          <div class="icon">!</div>
+        </div>
+
+        <h1 id="auth-error-title">Oops! Something Went Wrong</h1>
+        <p>We're sorry, but something unexpected happened. Please try again in a moment.</p>
+
+        <p class="support">
+          If the issue continues, please let us know by creating a <a href="${GITHUB_BUG_ISSUE_URL}" target="_blank" rel="noreferrer">GitHub Issue</a>.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>`;
+
+export const authError = (c: Context<{ Bindings: Env }>): Response =>
+  c.html(renderAuthErrorPage());

--- a/apps/www/src/features/error/view.tsx
+++ b/apps/www/src/features/error/view.tsx
@@ -11,6 +11,7 @@ export function ErrorView({ error }: { error: Error & { digest?: string } }) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-950">
       <div className="mx-auto max-w-md space-y-6 px-4 text-center">
+        {/* apps/api/src/presentation/http/auth-error.ts mirrors this page's generic copy and support path. */}
         {/* Error Icon */}
         <div className="flex justify-center">
           <div className="flex h-20 w-20 items-center justify-center rounded-full bg-red-500/20">


### PR DESCRIPTION
## Summary
- Add a custom API-rendered Better Auth error page for OAuth callback failures.
- Route Better Auth API errors to `/v1/api/auth/error` and keep the page outside Better Auth default UI.
- Mirror the frontend generic error copy and add comments on both implementations so the pages stay aligned.

## Why
Better Auth callback failures were showing the default Better Auth error page, which did not match PlaylistWizard error experience or provide a clear GitHub Issue support path.

## Notes
- The API page intentionally does not render Better Auth `error` or `error_description` query values.
- The API page uses fixed English copy matching the frontend English generic error page.

## Validation
- `pnpm -F @playlistwizard/api test`
- `pnpm -F @playlistwizard/api typecheck`
- `pnpm exec oxfmt --check apps/api/src/presentation/http/auth-error.ts apps/api/src/presentation/http/auth-error.test.ts apps/api/src/app.ts apps/api/src/infrastructure/auth/better-auth.ts apps/www/src/features/error/view.tsx`
- `pnpm -F @playlistwizard/api exec oxlint src/presentation/http/auth-error.ts src/presentation/http/auth-error.test.ts src/app.ts src/infrastructure/auth/better-auth.ts`