### PR TITLE
ci: allow Renovate to run Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+          allowed_bots: "renovate"
           track_progress: true
           prompt: |
             /review


### PR DESCRIPTION
## Summary

- Allow Renovate to run the Claude Review PR workflow.
- Add `allowed_bots: "renovate"` to the `anthropics/claude-code-action@v1` step.

## Why

`claude-code-action@v1` refuses to run for bot actors unless the bot is explicitly allow-listed. Renovate PRs trigger this workflow via `pull_request`, so Renovate needs to be included in `allowed_bots`.

## Validation

- Parsed `.github/workflows/claude-review.yml` with Ruby YAML.
- Pre-commit format and lint hooks passed during commit.
